### PR TITLE
Add AUR installation method

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -107,6 +107,9 @@ Remember, MicroBin will create your database and file storage wherever you execu
 
 `microbin --port 8080 --highlightsyntax --editable`
 
+### From AUR (for any Arch-based distro)
+Install `microbin` package from AUR and start/enable microbin systemd service. Systemd will start server on port 8080, which can be [changed](https://wiki.archlinux.org/title/Systemd#Editing_providd_units) via `systemctl edit microbin`. By default, almost all functions are enabled, and data is stored in `/var/lib/microbin`
+
 ### Building MicroBin
 
 Simply clone the repository, build it with `cargo build --release` and run the `microbin` executable in the created `target/release/` directory. It will start on port 8080. You can change the port with `-p` or `--port` CL arguments. For other arguments see [the Wiki](https://github.com/szabodanika/microbin/wiki).


### PR DESCRIPTION
AUR is Arch User Repository, "community-driven repository for Arch users. It contains package descriptions (PKGBUILDs) that allow you to compile a package from source with makepkg and then install it via pacman." 
I've made an AUR package that will allow any arch-based distro user to install and update microban to the latest version without manual version cheking&compiling. It will be easier for them to find it if you add information about this in the readme