### PR TITLE
Add bind address CL option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -105,11 +105,11 @@ Remember, MicroBin will create your database and file storage wherever you execu
 
 `cd ~/microbin/`
 
-`microbin --port 8080 --highlightsyntax --editable`
+`microbin --highlightsyntax --editable`
 
 ### Building MicroBin
 
-Simply clone the repository, build it with `cargo build --release` and run the `microbin` executable in the created `target/release/` directory. It will start on port 8080. You can change the port with `-p` or `--port` CL arguments. For other arguments see [the Wiki](https://github.com/szabodanika/microbin/wiki).
+Simply clone the repository, build it with `cargo build --release` and run the `microbin` executable in the created `target/release/` directory. It will start listening on 0.0.0.0:8080. You can change the port or bind address with CL arguments `-p (--port)` or `-b (--bind)` respectively . For other arguments see [the Wiki](https://github.com/szabodanika/microbin/wiki).
 
 ```
 git clone https://github.com/szabodanika/microbin.git
@@ -282,6 +282,13 @@ Enables syntax highlighting support. When creating a new pasta, a new dropdown s
 Default value: 8080
 
 Sets the port for the server will be listening on.
+
+
+### -b, --bind [ADDRESS]
+
+Default value: 0.0.0.0
+
+Sets the bind address for the server will be listening on. Both ipv4 and ipv6 are supported.
 
 ### --private
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use clap::Parser;
 use lazy_static::lazy_static;
 
@@ -36,7 +37,10 @@ pub struct Args {
     pub highlightsyntax: bool,
 
     #[clap(short, long, default_value_t = 8080)]
-    pub port: u32,
+    pub port: u16,
+
+    #[clap(short, long, default_value_t = IpAddr::from([127, 0, 0, 1]))]
+    pub bind: IpAddr,
 
     #[clap(long)]
     pub private: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,7 +39,7 @@ pub struct Args {
     #[clap(short, long, default_value_t = 8080)]
     pub port: u16,
 
-    #[clap(short, long, default_value_t = IpAddr::from([127, 0, 0, 1]))]
+    #[clap(short, long, default_value_t = IpAddr::from([0, 0, 0, 0]))]
     pub bind: IpAddr,
 
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ async fn main() -> std::io::Result<()> {
         .init();
 
     log::info!(
-        "MicroBin starting on http://127.0.0.1:{}",
+        "MicroBin starting on http://{}:{}",
+        ARGS.bind.to_string(),
         ARGS.port.to_string()
     );
 
@@ -97,7 +98,7 @@ async fn main() -> std::io::Result<()> {
                 HttpAuthentication::basic(util::auth::auth_validator),
             ))
     })
-    .bind(format!("0.0.0.0:{}", ARGS.port.to_string()))?
+    .bind((ARGS.bind, ARGS.port))?
     .workers(ARGS.threads as usize)
     .run()
     .await


### PR DESCRIPTION
As the title says, this PR adds the ability to explicitly specify the ip address the service is listening to. Default bind address is still 0.0.0.0