### PR TITLE
Adds file size to pasta with an attachment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ actix-web="4"
 actix-files="0.6.0"
 serde={ version = "1.0", features = ["derive"] }
 serde_json = "1.0.80"
+bytesize = { version = "1.1", features = ["serde"] }
 askama="0.10"
 askama-filters={ version = "0.1.3", features = ["chrono"] }
 chrono="0.4.19"

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -2,15 +2,21 @@ use std::fmt;
 
 use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
 use serde::{Deserialize, Serialize};
+use bytesize::ByteSize;
 
 use crate::util::animalnumbers::to_animal_names;
 use crate::util::syntaxhighlighter::html_highlight;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+pub struct PastaFile {
+    pub name: String, pub size: ByteSize ,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Pasta {
     pub id: u64,
     pub content: String,
-    pub file: String,
+    pub file: Option<PastaFile>,
     pub extension: String,
     pub private: bool,
     pub editable: bool,

--- a/templates/pasta.html
+++ b/templates/pasta.html
@@ -1,8 +1,8 @@
 {% include "header.html" %}
 <a style="margin-right: 0.5rem" href="/raw/{{pasta.id_as_animals()}}">Raw Text Content</a>
-{% if pasta.file != "no-file" %}
-<a style="margin-right: 0.5rem; margin-left: 0.5rem" href="/file/{{pasta.id_as_animals()}}/{{pasta.file}}">Attached file
-    '{{pasta.file}}'</a>
+{% if pasta.file.is_some() %}
+<a style="margin-right: 0.5rem; margin-left: 0.5rem" href="/file/{{pasta.id_as_animals()}}/{{pasta.file.as_ref().unwrap().name}}">Attached file
+	'{{pasta.file.as_ref().unwrap().name}}' [{{pasta.file.as_ref().unwrap().size}}]</a>
 {%- endif %}
 {% if pasta.editable %}
 <a style="margin-right: 0.5rem; margin-left: 0.5rem" href="/edit/{{pasta.id_as_animals()}}">Edit</a>

--- a/templates/pastalist.html
+++ b/templates/pastalist.html
@@ -48,8 +48,8 @@
         </td>
         <td>
             <a style="margin-right:1rem" href="/raw/{{pasta.id_as_animals()}}">Raw</a>
-            {% if pasta.file != "no-file" %}
-            <a style="margin-right:1rem" href="/file/{{pasta.id_as_animals()}}/{{pasta.file}}">File</a>
+            {% if pasta.file.is_some() %}
+            <a style="margin-right:1rem" href="/file/{{pasta.id_as_animals()}}/{{pasta.file.as_ref().unwrap().name}}">File</a>
             {%- endif %}
             {% if pasta.editable %}
             <a style="margin-right:1rem" href="/edit/{{pasta.id_as_animals()}}">Edit</a>


### PR DESCRIPTION
This introduces `PastaFile` which stores the name and size of a file attached to a pasta. To represent pasta's without file the pasta.file field type is changed from `String` to `Option<PastaFile>`. 

This adds *bytesize* as dependency. It is used to format the size of an attachment. Since cargo uses the bytesize crate I judge it to be fine dependency.
