### PR TITLE
add configuration from env to all clap options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ askama-filters={ version = "0.1.3", features = ["chrono"] }
 chrono="0.4.19"
 rand="0.8.5"
 linkify="0.8.1"
-clap={ version = "3.1.12", features = ["derive"] }
+clap={ version = "3.1.12", features = ["derive", "env"] }
 actix-multipart = "0.4.0"
 futures = "0.3"
 sanitize-filename = "0.3.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,7 +33,7 @@ pub struct Args {
     #[clap(long, env="MICROBIN_NO_LISTING")]
     pub no_listing: bool,
 
-    #[clap(long, env="MICROBIN_HIGHLIGHTINGSYNTAX")]
+    #[clap(long, env="MICROBIN_HIGHLIGHTSYNTAX")]
     pub highlightsyntax: bool,
 
     #[clap(short, long, env="MICROBIN_PORT", default_value_t = 8080)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,54 +9,54 @@ lazy_static! {
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_AUTH_USERNAME")]
     pub auth_username: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_AUTH_PASSWORD")]
     pub auth_password: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_EDITABLE")]
     pub editable: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_FOOTER_TEXT")]
     pub footer_text: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_HIDE_FOOTER")]
     pub hide_footer: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_HIDE_HEADER")]
     pub hide_header: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_HIDE_LOGO")]
     pub hide_logo: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_NO_LISTING")]
     pub no_listing: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_HIGHLIGHTINGSYNTAX")]
     pub highlightsyntax: bool,
 
-    #[clap(short, long, default_value_t = 8080)]
+    #[clap(short, long, env="MICROBIN_PORT", default_value_t = 8080)]
     pub port: u16,
 
-    #[clap(short, long, default_value_t = IpAddr::from([0, 0, 0, 0]))]
+    #[clap(short, long, env="MICROBIN_BIND", default_value_t = IpAddr::from([0, 0, 0, 0]))]
     pub bind: IpAddr,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_PRIVATE")]
     pub private: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_PURE_HTML")]
     pub pure_html: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_READONLY")]
     pub readonly: bool,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_TITLE")]
     pub title: Option<String>,
 
-    #[clap(short, long, default_value_t = 1)]
+    #[clap(short, long, env="MICROBIN_THREADS", default_value_t = 1)]
     pub threads: u8,
 
-    #[clap(long)]
+    #[clap(long, env="MICROBIN_WIDE")]
     pub wide: bool,
 }


### PR DESCRIPTION
this should fix #25
I added the env option to all clap arguments.
The Order of precenence is commandline option > env variable > default
from the naming of the environment variables it is "MICROBIN_" + the name of the option in all caps.

I tested it is working explicitly with the port option but expect it will work similarly for everything else.