### PR TITLE
fix usage of title arg in template

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    {% if args.footer_text.as_ref().is_none() %}
+    {% if args.title.as_ref().is_none() %}
         <title>MicroBin</title>
     {%- else %}
     <title>{{ args.title.as_ref().unwrap() }}</title>
@@ -42,7 +42,7 @@
         <i><span style="font-size:2.2rem; margin-right:1rem">μ</span></i>
     {%- endif %}
 
-    {% if args.footer_text.as_ref().is_none() %}
+    {% if args.title.as_ref().is_none() %}
         MicroBin
     {%- else %}
         {{ args.title.as_ref().unwrap() }}


### PR DESCRIPTION
fixes #37 
Title can now be properly set. this also fixed the None Unwrap happening when setting the footer-text option as described in #34 