### PR TITLE
DataStore agnostic API for Json and Sqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ env_logger = "0.9.0"
 actix-web-httpauth = "0.6.0"
 lazy_static = "1.4.0"
 syntect = "5.0"
-
+rusqlite = { version = "0.28.0", features = ["bundled"] }

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -7,12 +7,12 @@ use bytesize::ByteSize;
 use crate::util::animalnumbers::to_animal_names;
 use crate::util::syntaxhighlighter::html_highlight;
 
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct PastaFile {
     pub name: String, pub size: ByteSize ,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Pasta {
     pub id: u64,
     pub content: String,

--- a/src/util/dbio.rs
+++ b/src/util/dbio.rs
@@ -1,8 +1,62 @@
+use std::borrow::{Cow, Borrow};
 use std::fs::File;
 use std::io;
 use std::io::{BufReader, BufWriter};
+use std::sync::Mutex;
+use std::ops::Deref;
+use actix_web::web::Json;
 
 use crate::Pasta;
+
+pub trait DataStore {
+    fn remove_expired(&self);
+    fn edit(&self, id: u64, content: String);
+    fn create(&self, pasta: Pasta);
+    fn get_pasta(&self, id: u64) -> Option<Pasta>;
+    fn get_pastalist(&self) -> Box<dyn Deref<Target=Vec<Pasta>> + '_>;
+}
+
+
+pub struct JsonStore {
+    pub pastas: Mutex<Vec<Pasta>>
+}
+
+impl Default for JsonStore {
+    fn default() -> Self {
+        Self{pastas: Mutex::new(vec!())}
+    }
+}
+
+impl DataStore for JsonStore {
+    fn remove_expired(&self) {
+        
+    }
+
+    fn edit(&self, id: u64, content: String) {
+        todo!()
+    }
+
+    fn create(&self, pasta: Pasta) {
+        let mut pastas = self.pastas.lock().unwrap();
+        pastas.push(pasta);
+        save_to_file(&pastas);
+    }
+
+    fn get_pasta(&self, id: u64) -> Option<Pasta> {
+        let pastas = self.pastas.lock().unwrap();
+        for pasta in pastas.iter() {
+            if pasta.id == id {
+                return Some(pasta.clone());
+            }
+        }
+        None
+    }
+
+    fn get_pastalist(&self) -> Box<dyn Deref<Target=Vec<Pasta>> + '_>{
+        return Box::new(self.pastas.lock().unwrap());
+    }
+}
+
 
 static DATABASE_PATH: &'static str = "pasta_data/database.json";
 


### PR DESCRIPTION
this is by no means finished.

As I described on #4 there were some problems with making a proper api.
The idea being we have one central api used in the controllers that can be created dynamically at start time depending on arguments. But because of some differences and limitations of the existing api and sqlite I came up with this.

The types have certainly gotten a bit complex but I can add some more Type descriptions to make it easier to read. Currently I still have to implement one or two things to fully adapt the current Json storage to teh new api.
After that adding sqlite or even something else, or making changes in general should be easier.

I will await some feedback on your part before I proceed with this as there are already a lot of changes.