### PR TITLE
Expose port 8080 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,7 @@ COPY --from=build \
   /app/target/release/microbin \
   /usr/bin/microbin
 
+# Expose webport used for the webserver to the docker runtime
+EXPOSE 8080
+
 ENTRYPOINT ["microbin"]


### PR DESCRIPTION
Added a `EXPOSE 8080` to the Dockerfile to tell Docker that a container listens for traffic on that port. This will allows tools like Traefik to automatically pickup the port when setting up a reverse proxy. 