### PR TITLE
Checkbox to hide read counter per pasta

### DIFF
--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -54,6 +54,7 @@ pub async fn create(
         extension: String::from(""),
         private: false,
         editable: false,
+        hide_read_count: false,
         created: timenow,
         read_count: 0,
         burn_after_reads: 0,
@@ -72,6 +73,10 @@ pub async fn create(
             "private" => {
                 // while let Some(_chunk) = field.try_next().await? {}
                 new_pasta.private = true;
+                continue;
+            }
+            "hide_read_count" => {
+                new_pasta.hide_read_count = true;
                 continue;
             }
             "expiration" => {

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -40,6 +40,7 @@ pub struct Pasta {
     pub extension: String,
     pub private: bool,
     pub editable: bool,
+    pub hide_read_count: bool,
     pub created: i64,
     pub expiration: i64,
     pub last_read: i64,

--- a/templates/index.html
+++ b/templates/index.html
@@ -149,9 +149,7 @@
         {%- endif %}
 
         <div>
-            {% if args.editable || args.private %}
             <label>Other</label>
-            {%- endif %}
             {% if args.editable %}
             <div>
                 <input type="checkbox" id="editable" name="editable" value="editable">
@@ -164,6 +162,10 @@
                 <label for="private">Private</label>
             </div>
             {%- endif %}
+            <div>
+                <input type="checkbox" id="hide_read_count" name="hide_read_count" value="hide_read_count">
+                <label for="hide_read_count">Hide read count</label>
+            </div>
         </div>
     </div>
     <label>Content</label>
@@ -226,7 +228,7 @@
     #settings {
         display: grid;
         grid-gap: 6px;
-        grid-template-columns: repeat(auto-fit, 150px);
+        grid-template-columns: repeat(auto-fit, 160px);
         grid-template-rows: repeat(1, 90px);
         margin-bottom: 0.5rem;
     }

--- a/templates/pasta.html
+++ b/templates/pasta.html
@@ -49,6 +49,7 @@
   </div>
 </div>
 {%- endif %}
+{%- if ! pasta.hide_read_count %}
 <div>
   {% if pasta.read_count == 1 %}
   <p style="font-size: small">Read {{pasta.read_count}} time, last {{pasta.last_read_time_ago_as_string()}}</p>
@@ -57,6 +58,7 @@
   {%- endif %}
 
 </div>
+{%- endif %}
 
 <br>
 


### PR DESCRIPTION
In some instances, poster might want the read count to be hidden. Adds a checkbox to allow for better anonymization in that regard.