### PR TITLE
Add custom slug feature

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -92,6 +92,9 @@ pub struct Args {
 
     #[clap(long, env = "MICROBIN_HASH_IDS")]
     pub hash_ids: bool,
+
+    #[clap(long, env = "MICROBIN_SLUGS")]
+    pub slugs: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -37,7 +37,6 @@ pub async fn create(
             .finish());
     }
 
-
     let timenow: i64 = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(n) => n.as_secs(),
         Err(_) => {
@@ -203,6 +202,17 @@ pub async fn create(
 
     let id = new_pasta.id;
 
+    let mut pastas = data.pastas.lock().unwrap();
+
+    if let Some(slug) = &new_pasta.slug {
+        let pasta = pastas
+            .iter()
+            .find(|p| p.slug.is_some() && p.slug.as_ref().unwrap() == slug);
+        if pasta.is_some() {
+            new_pasta.slug = Some(format!("{}-{}", slug, to_animal_names(id)));
+        }
+    }
+
     let slug = if ARGS.hash_ids {
         to_hashids(id)
     } else if ARGS.slugs && new_pasta.slug.is_some() {
@@ -211,7 +221,6 @@ pub async fn create(
         to_animal_names(id)
     };
 
-    let mut pastas = data.pastas.lock().unwrap();
     pastas.push(new_pasta);
 
     save_to_file(&pastas);

--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -2,8 +2,6 @@ use crate::args::{Args, ARGS};
 use crate::dbio::save_to_file;
 use crate::endpoints::errors::ErrorTemplate;
 use crate::pasta::Pasta;
-use crate::util::animalnumbers::to_u64;
-use crate::util::hashids::to_u64 as hashid_to_u64;
 use crate::util::misc::remove_expired;
 use crate::AppState;
 
@@ -23,25 +21,11 @@ pub async fn getpasta(data: web::Data<AppState>, id: web::Path<String>) -> HttpR
     // get access to the pasta collection
     let mut pastas = data.pastas.lock().unwrap();
 
-    let id = if ARGS.hash_ids {
-        hashid_to_u64(&id).unwrap_or(0)
-    } else {
-        to_u64(&id.into_inner()).unwrap_or(0)
-    };
-
     // remove expired pastas (including this one if needed)
     remove_expired(&mut pastas);
 
     // find the index of the pasta in the collection based on u64 id
-    let mut index: usize = 0;
-    let mut found: bool = false;
-    for (i, pasta) in pastas.iter().enumerate() {
-        if pasta.id == id {
-            index = i;
-            found = true;
-            break;
-        }
-    }
+    let (index, found) = Pasta::get_index(id.as_ref(), &mut pastas);
 
     if found {
         // increment read count
@@ -87,26 +71,7 @@ pub async fn redirecturl(data: web::Data<AppState>, id: web::Path<String>) -> Ht
     // get access to the pasta collection
     let mut pastas = data.pastas.lock().unwrap();
 
-    let id = if ARGS.hash_ids {
-        hashid_to_u64(&id).unwrap_or(0)
-    } else {
-        to_u64(&id.into_inner()).unwrap_or(0)
-    };
-
-    // remove expired pastas (including this one if needed)
-    remove_expired(&mut pastas);
-
-    // find the index of the pasta in the collection based on u64 id
-    let mut index: usize = 0;
-    let mut found: bool = false;
-
-    for (i, pasta) in pastas.iter().enumerate() {
-        if pasta.id == id {
-            index = i;
-            found = true;
-            break;
-        }
-    }
+    let (index, found) = Pasta::get_index(id.as_ref(), &mut pastas);
 
     if found {
         // increment read count
@@ -154,25 +119,7 @@ pub async fn getrawpasta(data: web::Data<AppState>, id: web::Path<String>) -> St
     // get access to the pasta collection
     let mut pastas = data.pastas.lock().unwrap();
 
-    let id = if ARGS.hash_ids {
-        hashid_to_u64(&id).unwrap_or(0)
-    } else {
-        to_u64(&id.into_inner()).unwrap_or(0)
-    };
-
-    // remove expired pastas (including this one if needed)
-    remove_expired(&mut pastas);
-
-    // find the index of the pasta in the collection based on u64 id
-    let mut index: usize = 0;
-    let mut found: bool = false;
-    for (i, pasta) in pastas.iter().enumerate() {
-        if pasta.id == id {
-            index = i;
-            found = true;
-            break;
-        }
-    }
+    let (index, found) = Pasta::get_index(id.as_ref(), &mut pastas);
 
     if found {
         // increment read count

--- a/src/endpoints/remove.rs
+++ b/src/endpoints/remove.rs
@@ -2,7 +2,7 @@ use actix_web::{get, web, HttpResponse};
 
 use crate::args::ARGS;
 use crate::endpoints::errors::ErrorTemplate;
-use crate::pasta::PastaFile;
+use crate::pasta::{Pasta, PastaFile};
 use crate::util::animalnumbers::to_u64;
 use crate::util::hashids::to_u64 as hashid_to_u64;
 use crate::util::misc::remove_expired;
@@ -10,8 +10,8 @@ use crate::AppState;
 use askama::Template;
 use std::fs;
 
-#[get("/remove/{id}")]
-pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpResponse {
+#[get("/remove/{slug}")]
+pub async fn remove(data: web::Data<AppState>, slug: web::Path<String>) -> HttpResponse {
     if ARGS.readonly {
         return HttpResponse::Found()
             .append_header(("Location", format!("{}/", ARGS.public_path)))
@@ -21,37 +21,37 @@ pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpRes
     let mut pastas = data.pastas.lock().unwrap();
 
     let id = if ARGS.hash_ids {
-        hashid_to_u64(&id).unwrap_or(0)
+        hashid_to_u64(&slug).unwrap_or(0)
     } else {
-        to_u64(&id.into_inner()).unwrap_or(0)
+        to_u64(&slug).unwrap_or(0)
     };
 
+    let slug = slug.as_ref();
     for (i, pasta) in pastas.iter().enumerate() {
-        if pasta.id == id {
-            // remove the file itself
-            if let Some(PastaFile { name, .. }) = &pasta.file {
-                if fs::remove_file(format!(
-                    "./pasta_data/public/{}/{}",
-                    pasta.id_as_animals(),
-                    name
-                ))
-                .is_err()
-                {
-                    log::error!("Failed to delete file {}!", name)
-                }
+        match pasta.slug {
+            Some(ref s) if ARGS.slugs && s == slug => {
+                // remove the file itself
+                remove_file(pasta);
 
-                // and remove the containing directory
-                if fs::remove_dir(format!("./pasta_data/public/{}/", pasta.id_as_animals()))
-                    .is_err()
-                {
-                    log::error!("Failed to delete directory {}!", name)
-                }
+                // remove it from in-memory pasta list
+                pastas.remove(i);
+                return HttpResponse::Found()
+                    .append_header(("Location", format!("{}/pastalist", ARGS.public_path)))
+                    .finish();
             }
-            // remove it from in-memory pasta list
-            pastas.remove(i);
-            return HttpResponse::Found()
-                .append_header(("Location", format!("{}/pastalist", ARGS.public_path)))
-                .finish();
+            None if pasta.id == id => {
+                // remove the file itself
+                remove_file(pasta);
+
+                // remove it from in-memory pasta list
+                pastas.remove(i);
+                return HttpResponse::Found()
+                    .append_header(("Location", format!("{}/pastalist", ARGS.public_path)))
+                    .finish();
+            }
+            _ => {
+                continue;
+            }
         }
     }
 
@@ -60,4 +60,23 @@ pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpRes
     HttpResponse::Ok()
         .content_type("text/html")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
+}
+
+fn remove_file(pasta: &Pasta) {
+    if let Some(PastaFile { name, .. }) = &pasta.file {
+        if fs::remove_file(format!(
+            "./pasta_data/public/{}/{}",
+            pasta.id_as_animals(),
+            name
+        ))
+        .is_err()
+        {
+            log::error!("Failed to delete file {}!", name)
+        }
+
+        // and remove the containing directory
+        if fs::remove_dir(format!("./pasta_data/public/{}/", pasta.id_as_animals())).is_err() {
+            log::error!("Failed to delete directory {}!", name)
+        }
+    }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,6 +166,10 @@
             {%- endif %}
         </div>
     </div>
+    {% if args.slugs %}
+    <label>Slug</label>
+    <input type="text" style="width: 100%" name="slug" autofocus>
+    {%- endif %}
     <label>Content</label>
     <textarea style="width: 100%; min-height: 100px; margin-bottom: 2em" name="content" autofocus></textarea>
     <div style="overflow:auto;">


### PR DESCRIPTION
Added a few changes:
- New `--slug` argument to enable custom slug creation
- Hash id will still take precedence over this
- When a slug is already taken, the animal names will be appended to slug