### PR TITLE
Don't expose port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,4 @@ COPY --from=build \
   /app/target/release/microbin \
   /usr/bin/microbin
 
-# Expose webport used for the webserver to the docker runtime
-EXPOSE 8080
-
 ENTRYPOINT ["microbin"]


### PR DESCRIPTION
While the line `EXPOSE 8080` of the [Dockerfile](https://github.com/szabodanika/microbin/blob/0dbe9498f81168244d7741b1de2f2915ae0c1969/Dockerfile#L35) can be useful in some cases, there are also reasons against it.

The only benefit I see is that it is not necessary to add `-p 8080` with `docker run` if one wants to keep the default port ~~and enable external access to the service.~~

But a port that is once exposed can't be unexposed.

Example: If one adds an nginx reverse-proxy Docker container before the microbin service, then one would probably want that only the nginx service is reachable from the outside (e.g. on ports 80 and 443). So one would use `-p 80 -p 443` for nginx but omit the `-p` option with microbin. If one then runs `docker ps`, one can see that the port `8080` of microbin is still exposed. ~~Docker ignores some firewalls such as ufw resulting in external access directly to microbin.~~

There are some workarounds for this such as
- ~~binding the exposed port to localhost, e.g. `127.0.0.1:8080`~~
- ~~adding additional firewall rules~~
- using a script like [docker-copyedit](https://stackoverflow.com/a/50091221/6334421) to create a new Docker image without any exposed ports

~~I think it is cleaner to omit the `EXPOSE 8080` by default and if really needed, one can add it in a derived Dockerfile.~~