### PR TITLE
Use monospace font in textarea's

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -5,7 +5,7 @@
     </h4>
     <label>Content</label>
     <br>
-    <textarea style="width: 100%; min-height: 100px" name="content" id="content" autofocus>{{ pasta.content }}</textarea>
+    <textarea style="width: 100%; min-height: 100px; font-family: monospace;" name="content" id="content" autofocus>{{ pasta.content }}</textarea>
     <br>
 
     {% if args.readonly %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -173,7 +173,7 @@
         </div>
     </div>
     <label>Content</label>
-    <textarea style="width: 100%; min-height: 100px; margin-bottom: 2em" name="content" autofocus></textarea>
+    <textarea style="width: 100%; min-height: 100px; margin-bottom: 2em; font-family: monospace;" name="content" autofocus></textarea>
     <div style="overflow:auto;">
         {% if !args.no_file_upload %}
         <div style="float: left">


### PR DESCRIPTION
This commit makes the textareas (notably, when adding a pasta) use monospace font (which is in line with other pastebin services and arguably what the user wants/expects).