### PR TITLE
Escape backslash for Copy Text function

### DIFF
--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -144,7 +144,7 @@ impl Pasta {
     }
 
     pub fn content_escaped(&self) -> String {
-        html_escape::encode_text(&self.content.replace('`', "\\`").replace('$', "\\$")).to_string()
+        html_escape::encode_text(&self.content.replace('\\', "\\\\").replace('`', "\\`").replace('$', "\\$")).to_string()
     }
 }
 


### PR DESCRIPTION
I found not escaping backslashes in content would break Copy Text button:

> Uncaught SyntaxError: octal escape sequences can't be used in untagged template literals or in strict mode code

<img width="877" alt="repro" src="https://github.com/szabodanika/microbin/assets/10822203/e71ff0f7-a9e4-48c5-99ea-901f06de9e77">

Reproducible on v1.2.1 with a simple `\1` pasta. Firefox 113.

Here's the inline Javascript line that throws the error:

<img width="639" alt="source" src="https://github.com/szabodanika/microbin/assets/10822203/9149a176-fc57-4c2a-b397-e41cba091609">

Tested that simply escaping backslashes fixes the issue.
The `Copy Text` button now works as expected with pasta `\1`. :D