### PR TITLE
Prefix some XHRs with args.public_path_as_str()

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -38,7 +38,7 @@ padding-right:0.5rem; line-height: 1.5; font-size: 1.1em; padding-top: 2rem;">
                 {% if !args.hide_logo %}
                 <!-- <i><span style="font-size:2.2rem;
                 margin-right:1rem">μ</span></i> -->
-                <a href="/"><img width=100 style="margin-bottom: -6px; margin-right:
+                <a href="{{ args.public_path_as_str() }}"><img width=100 style="margin-bottom: -6px; margin-right:
                 0.5rem;" src="{{ args.public_path_as_str() }}/static/logo.png"></a>
                 {%- endif %} {% if args.title.as_ref().is_none() %} {%- else %} {{
                 args.title.as_ref().unwrap() }} {%- endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% include "header.html" %}
-<form id="pasta-form" action="upload" method="POST" enctype="multipart/form-data">
+<form id="pasta-form" action="{{ args.public_path_as_str() }}/upload" method="POST" enctype="multipart/form-data">
     <br>
     <div id="settings">
         <div>
@@ -281,7 +281,7 @@
         submitButton.textContent = 'Uploading...';
 
         const xhr = new XMLHttpRequest();
-        xhr.open('POST', '/upload', true);
+        xhr.open('POST', '{{ args.public_path_as_str() }}/upload', true);
 
         xhr.upload.onprogress = function (event) {
             if (showProgress) {

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -241,7 +241,7 @@ pasta.file_embeddable() && !pasta.encrypt_client %}
     // {%- endif %}
     formData.append('password', key);
 
-    const response = await fetch('/secure_file/{{ pasta.id_as_animals() }}', {
+    const response = await fetch('{{ args.public_path_as_str() }}/secure_file/{{ pasta.id_as_animals() }}', {
       method: 'POST',
       body: formData,
     })


### PR DESCRIPTION
When `--public-path` is set to a URL which is not at the web server root, i.e. `--public-path http://127.0.0.1/microbin` on the command line, saving a new pasta does not work, as the path to the `upload` XHR endpoint is set to `/upload` explicitly.

This pull request updates this and a couple of other places to use URLs relative to `args.public_path_as_str()`.