### PR TITLE
Update broken documentation link

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,7 +4,7 @@
 <div style="height: 200px;">
     <div style="float: left">
         <h4>Links</h4>
-        <a href="https://microbin.eu/documentation" style="margin-right: 1rem">Documentation and Help</a>
+        <a href="https://microbin.eu/docs/intro" style="margin-right: 1rem">Documentation and Help</a>
         <br>
         <a href="https://github.com/szabodanika/microbin" style="margin-right: 1rem">Source Code</a>
         <br>


### PR DESCRIPTION
Replace documentation link in Info page (https://microbin.eu/documentation) with new one: https://microbin.eu/docs/intro