### PR TITLE
Fix raw pastes returning 404

### DIFF
--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -304,7 +304,7 @@ pub async fn getrawpasta(
         pastas[index].last_read = timenow;
 
         // send raw content of pasta
-        let response = Ok(HttpResponse::NotFound()
+        let response = Ok(HttpResponse::Ok()
             .content_type("text/plain")
             .body(pastas[index].content.to_owned()));
 


### PR DESCRIPTION
Whenever a user visits the raw paste, the page is returned with a 404 status code, even if the paste exists. I assume this isn't intentional.

### Before:
![image](https://github.com/szabodanika/microbin/assets/25076630/93ad47b5-dd9d-4661-ae65-2d816776473e)

### After:
![image](https://github.com/szabodanika/microbin/assets/25076630/e991d0fc-6826-498d-9fa7-76c32a4a4b73)