### PR TITLE
Fix env file documentation and comments

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,10 @@
 # Default value: unset
 # export MICROBIN_BASIC_AUTH_PASSWORD=
 
+# Server timezone, select from
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+export TZ=Etc/UTC
+
 # Enables administrator interface at yourserver.com/admin/
 # if set, disables it if unset. If admin username is set but
 # admin password is not, just leave the password field empty

--- a/.env
+++ b/.env
@@ -38,7 +38,6 @@ export MICROBIN_ADMIN_PASSWORD=m1cr0b1n
 # finalised pastas but there will be an extra checkbox to
 # make your new pasta editable from the pasta list or the
 # pasta view page.
-# Default value: 8080 
 export MICROBIN_EDITABLE=true
 
 # Replaces the default footer text with your own. If you
@@ -48,21 +47,17 @@ export MICROBIN_EDITABLE=true
 # export MICROBIN_FOOTER_TEXT=
 
 # Hides the navigation bar on every page.
-# Default value: 8080 
 export MICROBIN_HIDE_HEADER=false
 
 # Hides the footer on every page.
-# Default value: 8080 
 export MICROBIN_HIDE_FOOTER=false
 
 # Hides the MicroBin logo from the navigation bar on every
 # page.
-# Default value: 8080 
 export MICROBIN_HIDE_LOGO=false
 
 # Disables the /pastalist endpoint, essentially making all
 # pastas private.
-# Default value: 8080 
 export MICROBIN_NO_LISTING=false
 
 # Enables syntax highlighting support. When creating a new
@@ -212,14 +207,14 @@ export MICROBIN_ENCRYPTION_CLIENT_SIDE=true
 export MICROBIN_ENCRYPTION_SERVER_SIDE=true
 
 # Limit the maximum file size users can upload without
-# encryption. Default value: 256.
-export MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB=256
+# encryption. Default value: 2048.
+export MICROBIN_MAX_FILE_SIZE_UNENCRYPTED_MB=2048
 
 # Limit the maximum file size users can upload with
 # encryption (more strain on your server than without
 # encryption, so the limit should be lower. Secrets tend to
-# be tiny files usually anyways.) Default value: 2048.
-export MICROBIN_MAX_FILE_SIZE_UNENCRYPTED_MB=2048
+# be tiny files usually anyways.) Default value: 256.
+export MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB=256
 
 # Disables the feature that checks for available updates
 #  when opening the admin screen.

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: danielszabo99/microbin:latest
     restart: always
     ports:
-     - "${MICROBIN_PORT}:8080"
+     - "8080:${MICROBIN_PORT}"
     volumes:
      - ./microbin-data:/app/microbin_data
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@ services:
     volumes:
      - ./microbin-data:/app/microbin_data
     environment:
+      TZ: ${TZ}
       MICROBIN_BASIC_AUTH_USERNAME: ${MICROBIN_BASIC_AUTH_USERNAME}
       MICROBIN_BASIC_AUTH_PASSWORD: ${MICROBIN_BASIC_AUTH_PASSWORD}
       MICROBIN_ADMIN_USERNAME: ${MICROBIN_ADMIN_USERNAME}


### PR DESCRIPTION
This fixes a few typos and incorrect defaults from the env file. It also adds support for the env variable TZ, which is supported by the docker image but was not documented.