### PR TITLE
Specify charset for non english words

### DIFF
--- a/src/endpoints/admin.rs
+++ b/src/endpoints/admin.rs
@@ -91,7 +91,7 @@ pub async fn post_admin(
         update = None;
     }
 
-    Ok(HttpResponse::Ok().content_type("text/html").body(
+    Ok(HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         AdminTemplate {
             pastas: &pastas,
             args: &ARGS,

--- a/src/endpoints/auth_admin.rs
+++ b/src/endpoints/auth_admin.rs
@@ -11,7 +11,7 @@ struct AuthAdmin<'a> {
 
 #[get("/auth_admin")]
 pub async fn auth_admin() -> HttpResponse {
-    return HttpResponse::Ok().content_type("text/html").body(
+    return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         AuthAdmin {
             args: &ARGS,
             status: String::from(""),
@@ -25,7 +25,7 @@ pub async fn auth_admin() -> HttpResponse {
 pub async fn auth_admin_with_status(param: web::Path<String>) -> HttpResponse {
     let status = param.into_inner();
 
-    return HttpResponse::Ok().content_type("text/html").body(
+    return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         AuthAdmin {
             args: &ARGS,
             status,

--- a/src/endpoints/auth_upload.rs
+++ b/src/endpoints/auth_upload.rs
@@ -33,7 +33,7 @@ pub async fn auth_upload(data: web::Data<AppState>, id: web::Path<String>) -> Ht
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id: id.into_inner(),
@@ -49,7 +49,7 @@ pub async fn auth_upload(data: web::Data<AppState>, id: web::Path<String>) -> Ht
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -73,7 +73,7 @@ pub async fn auth_upload_with_status(
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id,
@@ -89,7 +89,7 @@ pub async fn auth_upload_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -108,7 +108,7 @@ pub async fn auth_raw_pasta(data: web::Data<AppState>, id: web::Path<String>) ->
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id: id.into_inner(),
@@ -124,7 +124,7 @@ pub async fn auth_raw_pasta(data: web::Data<AppState>, id: web::Path<String>) ->
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -148,7 +148,7 @@ pub async fn auth_raw_pasta_with_status(
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id,
@@ -164,7 +164,7 @@ pub async fn auth_raw_pasta_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -183,7 +183,7 @@ pub async fn auth_edit_private(data: web::Data<AppState>, id: web::Path<String>)
 
     for (_, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id: id.into_inner(),
@@ -199,7 +199,7 @@ pub async fn auth_edit_private(data: web::Data<AppState>, id: web::Path<String>)
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -223,7 +223,7 @@ pub async fn auth_edit_private_with_status(
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id,
@@ -239,7 +239,7 @@ pub async fn auth_edit_private_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -258,7 +258,7 @@ pub async fn auth_file(data: web::Data<AppState>, id: web::Path<String>) -> Http
 
     for (_, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id: id.into_inner(),
@@ -274,7 +274,7 @@ pub async fn auth_file(data: web::Data<AppState>, id: web::Path<String>) -> Http
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -298,7 +298,7 @@ pub async fn auth_file_with_status(
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id,
@@ -314,7 +314,7 @@ pub async fn auth_file_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -333,7 +333,7 @@ pub async fn auth_remove_private(data: web::Data<AppState>, id: web::Path<String
 
     for (_, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id: id.into_inner(),
@@ -349,7 +349,7 @@ pub async fn auth_remove_private(data: web::Data<AppState>, id: web::Path<String
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -373,7 +373,7 @@ pub async fn auth_remove_private_with_status(
 
     for (_i, pasta) in pastas.iter().enumerate() {
         if pasta.id == intern_id {
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 AuthPasta {
                     args: &ARGS,
                     id,
@@ -389,6 +389,6 @@ pub async fn auth_remove_private_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -24,7 +24,7 @@ struct IndexTemplate<'a> {
 
 #[get("/")]
 pub async fn index() -> impl Responder {
-    HttpResponse::Ok().content_type("text/html").body(
+    HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         IndexTemplate {
             args: &ARGS,
             status: String::from(""),
@@ -38,7 +38,7 @@ pub async fn index() -> impl Responder {
 pub async fn index_with_status(param: web::Path<String>) -> HttpResponse {
     let status = param.into_inner();
 
-    return HttpResponse::Ok().content_type("text/html").body(
+    return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         IndexTemplate {
             args: &ARGS,
             status,

--- a/src/endpoints/edit.rs
+++ b/src/endpoints/edit.rs
@@ -48,7 +48,7 @@ pub async fn get_edit(data: web::Data<AppState>, id: web::Path<String>) -> HttpR
                     .finish();
             }
 
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 EditTemplate {
                     pasta,
                     args: &ARGS,
@@ -62,7 +62,7 @@ pub async fn get_edit(data: web::Data<AppState>, id: web::Path<String>) -> HttpR
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -100,7 +100,7 @@ pub async fn get_edit_with_status(
                     .finish();
             }
 
-            return HttpResponse::Ok().content_type("text/html").body(
+            return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
                 EditTemplate {
                     pasta,
                     args: &ARGS,
@@ -114,7 +114,7 @@ pub async fn get_edit_with_status(
     }
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -183,7 +183,7 @@ pub async fn post_edit_private(
         }
 
         // serve pasta in template
-        let response = HttpResponse::Ok().content_type("text/html").body(
+        let response = HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
             EditTemplate {
                 pasta: &pastas[index],
                 args: &ARGS,
@@ -201,7 +201,7 @@ pub async fn post_edit_private(
         return Ok(response);
     }
     Ok(HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap()))
 }
 
@@ -294,7 +294,7 @@ pub async fn post_submit_edit_private(
             .finish());
     }
     Ok(HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap()))
 }
 
@@ -379,6 +379,6 @@ pub async fn post_edit(
     }
 
     Ok(HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap()))
 }

--- a/src/endpoints/errors.rs
+++ b/src/endpoints/errors.rs
@@ -11,6 +11,6 @@ pub struct ErrorTemplate<'a> {
 
 pub async fn not_found() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap()))
 }

--- a/src/endpoints/guide.rs
+++ b/src/endpoints/guide.rs
@@ -11,6 +11,6 @@ struct Guide<'a> {
 #[get("/guide")]
 pub async fn guide() -> HttpResponse {
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(Guide { args: &ARGS }.render().unwrap())
 }

--- a/src/endpoints/list.rs
+++ b/src/endpoints/list.rs
@@ -28,7 +28,7 @@ pub async fn list(data: web::Data<AppState>) -> HttpResponse {
     // sort pastas in reverse-chronological order of creation time
     pastas.sort_by(|a, b| b.created.cmp(&a.created));
 
-    HttpResponse::Ok().content_type("text/html").body(
+    HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
         ListTemplate {
             pastas: &pastas,
             args: &ARGS,

--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -84,7 +84,7 @@ fn pastaresponse(
         }
 
         // serve pasta in template
-        let response = HttpResponse::Ok().content_type("text/html").body(
+        let response = HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
             PastaTemplate {
                 pasta: &pastas[index],
                 args: &ARGS,
@@ -117,7 +117,7 @@ fn pastaresponse(
 
     // otherwise send pasta not found error
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -226,14 +226,14 @@ fn urlresponse(data: web::Data<AppState>, id: web::Path<String>) -> HttpResponse
         // send error if we're trying to open a non-url pasta as a redirect
         } else {
             HttpResponse::Ok()
-                .content_type("text/html")
+                .content_type("text/html; charset=utf-8")
                 .body(ErrorTemplate { args: &ARGS }.render().unwrap());
         }
     }
 
     // otherwise send pasta not found error
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -313,7 +313,7 @@ pub async fn getrawpasta(
 
     // otherwise send pasta not found error as raw text
     Ok(HttpResponse::NotFound()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(String::from("Upload not found! :-(")))
 }
 
@@ -408,7 +408,7 @@ pub async fn postrawpasta(
 
         // send raw content of pasta
         let response = Ok(HttpResponse::NotFound()
-            .content_type("text/html")
+            .content_type("text/html; charset=utf-8")
             .body(pastas[index].content.to_owned()));
 
         if pastas[index].content != original_content {
@@ -420,7 +420,7 @@ pub async fn postrawpasta(
 
     // otherwise send pasta not found error as raw text
     Ok(HttpResponse::NotFound()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(String::from("Upload not found! :-(")))
 }
 

--- a/src/endpoints/qr.rs
+++ b/src/endpoints/qr.rs
@@ -53,7 +53,7 @@ pub async fn getqr(data: web::Data<AppState>, id: web::Path<String>) -> HttpResp
         };
 
         // serve qr code in template
-        return HttpResponse::Ok().content_type("text/html").body(
+        return HttpResponse::Ok().content_type("text/html; charset=utf-8").body(
             QRTemplate {
                 qr: &svg,
                 pasta: &pastas[index],
@@ -67,6 +67,6 @@ pub async fn getqr(data: web::Data<AppState>, id: web::Path<String>) -> HttpResp
     // otherwise
     // send pasta not found error
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }

--- a/src/endpoints/remove.rs
+++ b/src/endpoints/remove.rs
@@ -74,7 +74,7 @@ pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpRes
     remove_expired(&mut pastas);
 
     HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap())
 }
 
@@ -178,6 +178,6 @@ pub async fn post_remove(
     }
 
     Ok(HttpResponse::Ok()
-        .content_type("text/html")
+        .content_type("text/html; charset=utf-8")
         .body(ErrorTemplate { args: &ARGS }.render().unwrap()))
 }


### PR DESCRIPTION
Some broswer like Firefox and Safari can't parse Chinese chracter without charset in header, so specified as UTF-8 for all response.