### PR TITLE
Attachments compatible with absolute path

### DIFF
--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -229,14 +229,14 @@ pub async fn create(
                 };
 
                 std::fs::create_dir_all(format!(
-                    "./{}/attachments/{}",
+                    "{}/attachments/{}",
                     ARGS.data_dir,
                     &new_pasta.id_as_animals()
                 ))
                 .unwrap();
 
                 let filepath = format!(
-                    "./{}/attachments/{}/{}",
+                    "{}/attachments/{}/{}",
                     ARGS.data_dir,
                     &new_pasta.id_as_animals(),
                     &file.name()
@@ -290,7 +290,7 @@ pub async fn create(
 
     if new_pasta.file.is_some() && new_pasta.encrypt_server && !new_pasta.readonly {
         let filepath = format!(
-            "./{}/attachments/{}/{}",
+            "{}/attachments/{}/{}",
             ARGS.data_dir,
             &new_pasta.id_as_animals(),
             &new_pasta.file.as_ref().unwrap().name()

--- a/src/endpoints/file.rs
+++ b/src/endpoints/file.rs
@@ -52,7 +52,7 @@ pub async fn post_secure_file(
     if found {
         if let Some(ref pasta_file) = pastas[index].file {
             let file = File::open(format!(
-                "./{}/attachments/{}/data.enc",
+                "{}/attachments/{}/data.enc",
                 ARGS.data_dir,
                 pastas[index].id_as_animals()
             ))?;
@@ -119,7 +119,7 @@ pub async fn get_file(
 
             // Construct the path to the file
             let file_path = format!(
-                "./{}/attachments/{}/{}",
+                "{}/attachments/{}/{}",
                 ARGS.data_dir,
                 pastas[index].id_as_animals(),
                 pasta_file.name()

--- a/src/endpoints/remove.rs
+++ b/src/endpoints/remove.rs
@@ -38,7 +38,7 @@ pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpRes
             // remove the file itself
             if let Some(PastaFile { name, .. }) = &pasta.file {
                 if fs::remove_file(format!(
-                    "./{}/attachments/{}/{}",
+                    "{}/attachments/{}/{}",
                     ARGS.data_dir,
                     pasta.id_as_animals(),
                     name
@@ -50,7 +50,7 @@ pub async fn remove(data: web::Data<AppState>, id: web::Path<String>) -> HttpRes
 
                 // and remove the containing directory
                 if fs::remove_dir(format!(
-                    "./{}/attachments/{}/",
+                    "{}/attachments/{}/",
                     ARGS.data_dir,
                     pasta.id_as_animals()
                 ))
@@ -113,7 +113,7 @@ pub async fn post_remove(
                         // remove the file itself
                         if let Some(PastaFile { name, .. }) = &pasta.file {
                             if fs::remove_file(format!(
-                                "./{}/attachments/{}/{}",
+                                "{}/attachments/{}/{}",
                                 ARGS.data_dir,
                                 pasta.id_as_animals(),
                                 name
@@ -125,7 +125,7 @@ pub async fn post_remove(
 
                             // and remove the containing directory
                             if fs::remove_dir(format!(
-                                "./{}/attachments/{}/",
+                                "{}/attachments/{}/",
                                 ARGS.data_dir,
                                 pasta.id_as_animals()
                             ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,16 +75,16 @@ async fn main() -> std::io::Result<()> {
         ARGS.port.to_string()
     );
 
-    match fs::create_dir_all(format!("./{}/public", ARGS.data_dir)) {
+    match fs::create_dir_all(format!("{}/public", ARGS.data_dir)) {
         Ok(dir) => dir,
         Err(error) => {
             log::error!(
-                "Couldn't create data directory ./{}/attachments/: {:?}",
+                "Couldn't create data directory {}/attachments/: {:?}",
                 ARGS.data_dir,
                 error
             );
             panic!(
-                "Couldn't create data directory ./{}/attachments/: {:?}",
+                "Couldn't create data directory {}/attachments/: {:?}",
                 ARGS.data_dir, error
             );
         }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -41,7 +41,7 @@ pub fn remove_expired(pastas: &mut Vec<Pasta>) {
             // remove the file itself
             if let Some(file) = &p.file {
                 if fs::remove_file(format!(
-                    "./{}/attachments/{}/{}",
+                    "{}/attachments/{}/{}",
                     ARGS.data_dir,
                     p.id_as_animals(),
                     file.name()
@@ -53,7 +53,7 @@ pub fn remove_expired(pastas: &mut Vec<Pasta>) {
 
                 // and remove the containing directory
                 if fs::remove_dir(format!(
-                    "./{}/attachments/{}/",
+                    "{}/attachments/{}/",
                     ARGS.data_dir,
                     p.id_as_animals()
                 ))


### PR DESCRIPTION
Make the change to allow attachments to works with an absolute `data_dir` path.
No change needed for `sqlite` since it was already working.