### PR TITLE
Update typos in .env

### DIFF
--- a/.env
+++ b/.env
@@ -38,7 +38,7 @@ export MICROBIN_ADMIN_PASSWORD=m1cr0b1n
 # finalised pastas but there will be an extra checkbox to
 # make your new pasta editable from the pasta list or the
 # pasta view page.
-# Default value: 8080 
+# Default value: true 
 export MICROBIN_EDITABLE=true
 
 # Replaces the default footer text with your own. If you
@@ -48,21 +48,21 @@ export MICROBIN_EDITABLE=true
 # export MICROBIN_FOOTER_TEXT=
 
 # Hides the navigation bar on every page.
-# Default value: 8080 
+# Default value: false 
 export MICROBIN_HIDE_HEADER=false
 
 # Hides the footer on every page.
-# Default value: 8080 
+# Default value: false 
 export MICROBIN_HIDE_FOOTER=false
 
 # Hides the MicroBin logo from the navigation bar on every
 # page.
-# Default value: 8080 
+# Default value: false 
 export MICROBIN_HIDE_LOGO=false
 
 # Disables the /pastalist endpoint, essentially making all
 # pastas private.
-# Default value: 8080 
+# Default value: false 
 export MICROBIN_NO_LISTING=false
 
 # Enables syntax highlighting support. When creating a new


### PR DESCRIPTION
Fixed typos in the comments, that relate to default values