### PR TITLE
Fix never expire condition

### DIFF
--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -58,9 +58,9 @@ pub fn expiration_to_timestamp(expiration: &str, timenow: i64) -> i64 {
         "1week" => timenow + 60 * 60 * 24 * 7,
         "never" => {
             if ARGS.eternal_pasta {
-                timenow + 60 * 60 * 24 * 7
-            } else {
                 0
+            } else {
+                timenow + 60 * 60 * 24 * 7
             }
         }
         _ => {


### PR DESCRIPTION
The bodies of `if`/`else` were inverted due to which, even if user selects "Never" as the expiry option, the paste would be created with an expiration date. I've flipped the bodies so that selecting "Never" actually creates a never-expiring paste.
