### PR TITLE
Add slim healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN \
   CARGO_NET_GIT_FETCH_WITH_CLI=true \
   cargo build --release
 
+# build a healthcheck binary
+RUN cd healthcheck && cargo build --release
+
 # https://hub.docker.com/r/bitnami/minideb
 FROM bitnami/minideb:latest
 
@@ -34,6 +37,11 @@ COPY --from=build \
 COPY --from=build \
   /app/target/release/microbin \
   /usr/bin/microbin
+
+# copy healthcheck executable
+COPY --from=build \
+  /app/healthcheck/target/release/healthcheck \
+  /usr/bin/healthcheck
 
 # Expose webport used for the webserver to the docker runtime
 EXPOSE 8080

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
      - "${MICROBIN_PORT}:8080"
     volumes:
      - ./microbin-data:/app/microbin_data
+    healthcheck:
+      test: healthcheck
     environment:
       MICROBIN_BASIC_AUTH_USERNAME: ${MICROBIN_BASIC_AUTH_USERNAME}
       MICROBIN_BASIC_AUTH_PASSWORD: ${MICROBIN_BASIC_AUTH_PASSWORD}

--- a/healthcheck/Cargo.toml
+++ b/healthcheck/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "healthcheck"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "healthcheck"
+path = "main.rs"
+
+[dependencies]
+minreq = "2.11.2"

--- a/healthcheck/main.rs
+++ b/healthcheck/main.rs
@@ -1,0 +1,35 @@
+use std::{env, process::ExitCode};
+
+// defaults to the 8080 port
+// takes an APP_PORT var but APP_PORT is not implemented in the app 
+// I didn't do that since this is not really the point of the PR
+// this just proves it can be done and can be built on
+fn main() -> ExitCode {
+    let port = env::var("APP_PORT").unwrap_or_else(|_| String::from("8080"));
+
+    // uses http, if you eventually add TLS support then you need more dependencies
+    // as mentioned in this blog you would need 17 more dependencies, to have rustls
+    // making it a 	531kb -> 1.2mb binary
+    // which at that point it approaches the size of wget from busybox
+    // so that could be more efficient at that point
+    // https://natalia.dev/blog/2023/03/docker-health-checks-on-distroless-containers-with-rust
+    let endpoint = format!("http://localhost:{}/", port);
+
+    let res = minreq::get(endpoint).send();
+
+    if res.is_err() {
+        println!("{}", res.unwrap_err());
+        return ExitCode::from(1);
+    }
+
+    let code = res.unwrap().status_code;
+
+    // I altered the .rs file in the blog above
+    // this is more strict, it will only claim healthy if code 200-399
+    if (200..=399).contains(&code) {
+        return ExitCode::from(0)
+    }
+
+    println!("Did not recieve a 200-399 code, the service is likely down {}", code);
+    return ExitCode::from(1);
+}


### PR DESCRIPTION
I put out a Issue [here](https://github.com/szabodanika/microbin/issues/240) where I requested healthchecks. I looked back on it since I also saw someone else requesting it on Reddit [here](https://www.reddit.com/r/selfhosted/comments/14x36vs/comment/jrmsngl).

I wanted to see if I could find an efficient way to add them into this project.

Like I mentioned in my issue there are several ways to do Docker healthchecks.

The simplest is to use a wget or curl command. However, in your selected image `bitnami/minideb`. Those are not there. An alternative at that point can be to use `netcat` / `nc` but that also is not installed.

Since this image is close to distroless and that is a good spot to be in for Docker images. I investigated trying to add healthchecks while still keeping the image as small as possible

![image](https://github.com/szabodanika/microbin/assets/61724833/b367841d-9557-4481-9518-88d561b6a976)

I was able to use a [blog](https://natalia.dev/blog/2023/03/docker-health-checks-on-distroless-containers-with-rust/) I found to make a 608Kb healthcheck. 

A more maintainable alternative would be to use `minideb`'s `install_packages wget`  and perform a wget healthcheck like this

```sh
wget --no-verbose --tries=1 --spider http://localhost:8080 || exit 1
```

This wget install would add `4.78Mb` in size to the image. But would be minimal in code (1 line of Dockerfile code). However, if you went further down the distroless images with something like `gcr.io/distroless/static`. Then you would no longer be able to use a debian package manager and would need to get the package from busybox with something like this:

```dockerfile
FROM busybox:uclibc AS busybox
FROM gcr.io/distroless/static

COPY --from=busybox /bin/wget /usr/bin/wget
```

Which should only add 1.17Mb, so not too bad there. As another alternative solution that would only be 2 lines of Dockerfile code.


Just wanted to lay out some options for your project. If you value image size & security we can refine this PR. If you just want maintainability then the 1 line `install_packages` command should work fine for your minideb image you've selected.

Thanks for putting this project out there I've been really enjoying it.

### logs
When I tested this docker-compose.yml the health checks spammed the logs (I think it sends one every ~10-30 seconds. It might be useful to have an endpoint that doesn't create a stdout log and have the health check hit that endpoint instead

### app_port
The .rs file I committed can accept an app_port configuration. But I think it's fine to be opinionated and use an unconfigurable port 8080 app side. Especially with how many env vars already exist for the project.

So that's something that should get removed from my pr. 