### PR TITLE
Fix privacyDropdown is null issue

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -142,7 +142,7 @@
         {%- endif %}
 
         <div>
-            <label for="syntax_highlight">Privacy <sup> <a href="/guide#privacy">﹖</a></sup></label><br>
+            <label for="privacy">Privacy <sup> <a href="/guide#privacy">﹖</a></sup></label><br>
             <select style="width: 100%;" name="privacy" id="privacy">
                 <optgroup label="Unencrypted (no password)">
                     <option value="public">Public</option>


### PR DESCRIPTION
The issue:

```text
Uncaught TypeError: Cannot read properties of null (reading 'value')
    at fileOversized ((index):239:33)
    at HTMLInputElement.<anonymous> ((index):284:9)
```

Related JS code:

```javascript
159    const privacyDropdown = document.getElementById("privacy");

239            if (privacyDropdown.value == "secret") {
```