### PR TITLE
Fix #235

### DIFF
--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -175,13 +175,13 @@ pub async fn create(
             "burn_after" => {
                 while let Some(chunk) = field.try_next().await? {
                     new_pasta.burn_after_reads = match std::str::from_utf8(&chunk).unwrap() {
-                        // give an extra read because the user will be
+                        // give two extra each time just because the user will be
                         // redirected to the pasta page automatically
                         "1" => 2,
-                        "10" => 10,
-                        "100" => 100,
-                        "1000" => 1000,
-                        "10000" => 10000,
+                        "10" => 11,
+                        "100" => 101,
+                        "1000" => 1001,
+                        "10000" => 10001,
                         "0" => 0,
                         _ => {
                             log::error!("{}", "Unexpected burn after value!");
@@ -332,7 +332,7 @@ pub async fn create(
     } else {
         Ok(HttpResponse::Found()
             .append_header((
-                "Location",
+                "pasta_url",
                 format!("{}/upload/{}", ARGS.public_path_as_str(), slug),
             ))
             .finish())

--- a/templates/index.html
+++ b/templates/index.html
@@ -299,7 +299,7 @@
         xhr.onreadystatechange = function () {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.status === 200 || xhr.status === 302) {
-                    window.location.href = xhr.responseURL;
+                    window.location.href = xhr.getResponseHeader('pasta_url');
                 } else {
                     console.log('Request failed with status:', xhr.status);
                 }


### PR DESCRIPTION
By sending the upload URL back to the browser with a custom header name rather than the standard Location, the browser doesn't get "redirected twice", hence only one GET request made and fixing #235