### PR TITLE
Support default privacy setting

### DIFF
--- a/.env
+++ b/.env
@@ -204,6 +204,15 @@ export MICROBIN_ENCRYPTION_CLIENT_SIDE=true
 # Default value: false
 export MICROBIN_ENCRYPTION_SERVER_SIDE=true
 
+# Sets the default privacy level for new pastas. Available options:
+# public - shows in listing, no password required
+# unlisted - doesn't show in listing, accessible with URL, requires MICROBIN_PRIVATE=true
+# readonly - unlisted, accessible without password but can't edit/delete, requires MICROBIN_ENABLE_READONLY=true
+# private - server-side encrypted
+# secret - E2E encrypted, server can't read content, requires MICROBIN_ENCRYPTION_CLIENT_SIDE=true
+# Default value: public)
+# export MICROBIN_DEFAULT_PRIVACY=
+
 # Limit the maximum file size users can upload without
 # encryption. Default value: 256.
 export MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB=256

--- a/src/args.rs
+++ b/src/args.rs
@@ -133,6 +133,9 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_ENCRYPTION_SERVER_SIDE")]
     pub encryption_server_side: bool,
 
+    #[clap(long, env = "MICROBIN_DEFAULT_PRIVACY")]
+    pub default_privacy: Option<String>,
+
     #[clap(
         long,
         env = "MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB",
@@ -213,6 +216,7 @@ impl Args {
             disable_telemetry: self.disable_telemetry,
             encryption_client_side: self.encryption_client_side,
             encryption_server_side: self.encryption_server_side,
+            default_privacy: None,
             max_file_size_encrypted_mb: self.max_file_size_encrypted_mb,
             max_file_size_unencrypted_mb: self.max_file_size_unencrypted_mb,
             disable_update_checking: self.disable_update_checking,

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -23,6 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 struct IndexTemplate<'a> {
     args: &'a Args,
     status: String,
+    default_privacy_value: String,
 }
 
 #[get("/")]
@@ -31,6 +32,7 @@ pub async fn index() -> impl Responder {
         IndexTemplate {
             args: &ARGS,
             status: String::from(""),
+            default_privacy_value: ARGS.default_privacy.as_ref().map_or_else(|| String::from("public"), |s| s.clone()),
         }
         .render()
         .unwrap(),
@@ -45,6 +47,7 @@ pub async fn index_with_status(param: web::Path<String>) -> HttpResponse {
         IndexTemplate {
             args: &ARGS,
             status,
+            default_privacy_value: ARGS.default_privacy.as_ref().map_or_else(|| String::from("public"), |s| s.clone()),
         }
         .render()
         .unwrap(),

--- a/templates/index.html
+++ b/templates/index.html
@@ -145,23 +145,23 @@
             <label for="privacy">Privacy <sup> <a href="{{ args.public_path_as_str() }}/guide#privacy">?</a></sup></label><br>
             <select style="width: 100%;" name="privacy" id="privacy">
                 <optgroup label="Unencrypted (no password)">
-                    <option value="public">Public</option>
+                    <option value="public"{% if default_privacy_value == "public" %} selected{% endif %}>Public</option>
                     {% if args.private %}
-                    <option value="unlisted">Unlisted</option>
+                    <option value="unlisted"{% if default_privacy_value == "unlisted" %} selected{% endif %}>Unlisted</option>
                     {%- endif %}
                 </optgroup>
                 {% if args.enable_readonly %}
                 <optgroup label="Unencrypted (protected)">
-                    <option value="readonly">Read-only</option>
+                    <option value="readonly"{% if default_privacy_value == "readonly" %} selected{% endif %}>Read-only</option>
                 </optgroup>
                 {%- endif %}
                 {% if args.encryption_client_side || args.encryption_server_side %}
                 <optgroup label="Encrypted">
                     {% if args.encryption_server_side %}
-                    <option value="private">Private</option>
+                    <option value="private"{% if default_privacy_value == "private" %} selected{% endif %}>Private</option>
                     {%- endif %}
                     {% if args.encryption_client_side%}
-                    <option value="secret">Secret</option>
+                    <option value="secret"{% if default_privacy_value == "secret" %} selected{% endif %}>Secret</option>
                     {%- endif %}
                 </optgroup>
                 {%- endif %}


### PR DESCRIPTION
Add support for a default privacy level for new pastas with the MICROBIN_DEFAULT_PRIVACY option in .env and public as default value. Implements #220