### PR TITLE
Support file:// ARG secrets

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,8 @@
 # https://username:password@yourserver.net or
 # https://username@yourserver.net if password is not set
 # instead of typing into the password
+# Supports reading the value from a file e.g. file://secret_password.txt
+# Use file:// preset, then global/local path.
 # Default value: unset
 # export MICROBIN_BASIC_AUTH_USERNAME=
 
@@ -16,6 +18,8 @@
 # to https://username:password@yourserver.net or
 # https://username@yourserver.net if password is not set
 # instead of typing into the password prompt.
+# Supports reading the value from a file e.g. file://secret_password.txt
+# Use file:// preset, then global/local path.
 # Default value: unset
 # export MICROBIN_BASIC_AUTH_PASSWORD=
 
@@ -23,8 +27,16 @@
 # if set, disables it if unset. If admin username is set but
 # admin password is not, just leave the password field empty
 # when logging in. 
+# Supports reading the value from a file e.g. file://secret_password.txt
+# Use file:// preset, then global/local path.
 # Default value: admin
 export MICROBIN_ADMIN_USERNAME=admin
+
+# Enables administrator interface password at yourserver.com/admin/
+# Supports reading the value from a file e.g. file://secret_password.txt
+# Use file:// preset, then global/local path.
+# Default value: admin
+export MICROBIN_ADMIN_PASSWORD=admin
 
 # Enables administrator interface at yourserver.com/admin/
 # if set, disables it if unset. Will not have any affect
@@ -103,6 +115,8 @@ export MICROBIN_JSON_DB=false
 # MICROBIN_SHORT_PATH=
 
 # The password required for uploading, if read-only mode is enabled
+# Supports reading the value from a file e.g. file://secret_password.txt
+# Use file:// preset, then global/local path.
 # Default value: unset
 # export MICROBIN_UPLOADER_PASSWORD=
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,6 +5,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::net::IpAddr;
 use std::str::FromStr;
+use crate::fs;
 
 lazy_static! {
     pub static ref ARGS: Args = Args::parse();
@@ -14,16 +15,16 @@ lazy_static! {
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     #[clap(long, env = "MICROBIN_BASIC_AUTH_USERNAME")]
-    pub auth_basic_username: Option<String>,
+    pub auth_basic_username: Option<SecretArg>,
 
     #[clap(long, env = "MICROBIN_BASIC_AUTH_PASSWORD")]
-    pub auth_basic_password: Option<String>,
+    pub auth_basic_password: Option<SecretArg>,
 
     #[clap(long, env = "MICROBIN_ADMIN_USERNAME", default_value = "admin")]
-    pub auth_admin_username: String,
+    pub auth_admin_username: SecretArg,
 
     #[clap(long, env = "MICROBIN_ADMIN_PASSWORD", default_value = "m1cr0b1n")]
-    pub auth_admin_password: String,
+    pub auth_admin_password: SecretArg,
 
     #[clap(long, env = "MICROBIN_EDITABLE")]
     pub editable: bool,
@@ -68,7 +69,7 @@ pub struct Args {
     pub short_path: Option<PublicUrl>,
 
     #[clap(long, env = "MICROBIN_UPLOADER_PASSWORD")]
-    pub uploader_password: Option<String>,
+    pub uploader_password: Option<SecretArg>,
 
     #[clap(long, env = "MICROBIN_READONLY")]
     pub readonly: bool,
@@ -179,8 +180,8 @@ impl Args {
         Args {
             auth_basic_username: None,
             auth_basic_password: None,
-            auth_admin_username: String::from(""),
-            auth_admin_password: String::from(""),
+            auth_admin_username: crate::args::SecretArg(String::from("")),
+            auth_admin_password: crate::args::SecretArg(String::from("")),
             editable: self.editable,
             footer_text: self.footer_text,
             hide_footer: self.hide_footer,
@@ -232,6 +233,33 @@ pub struct PublicUrl(pub String);
 impl fmt::Display for PublicUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SecretArg(pub String);
+
+impl FromStr for SecretArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(path) = s.strip_prefix("file://").or_else(|| s.strip_prefix("file:")) {
+            // Read value from file
+            fs::read_to_string(path)
+                .map(|content| SecretArg(content.trim().to_string()))
+                .map_err(|e| format!("Failed to read secret from {}: {}", path, e))
+        } else {
+            // Use the raw string provided
+            Ok(SecretArg(s.to_string()))
+        }
+    }
+}
+
+// Allow it to be treated like a string automatically
+impl std::ops::Deref for SecretArg {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/src/endpoints/admin.rs
+++ b/src/endpoints/admin.rs
@@ -46,7 +46,7 @@ pub async fn post_admin(
         }
     }
 
-    if username != ARGS.auth_admin_username || password != ARGS.auth_admin_password {
+    if username != **ARGS.auth_admin_username || password != *ARGS.auth_admin_password {
         return Ok(HttpResponse::Found()
             .append_header(("Location", format!("{}/auth_admin/incorrect", ARGS.public_path_as_str())))
             .finish());
@@ -68,7 +68,7 @@ pub async fn post_admin(
         message = "Warning: No public URL set with --public-path parameter. QR code and URL Copying functions have been disabled"
     }
 
-    if ARGS.auth_admin_username == "admin" && ARGS.auth_admin_password == "m1cr0b1n" {
+    if *ARGS.auth_admin_username == "admin" && *ARGS.auth_admin_password == "m1cr0b1n" {
         status = "WARNING";
         message = "Warning: You are using the default admin login details. This is a security risk, please change them."
     }

--- a/src/endpoints/remove.rs
+++ b/src/endpoints/remove.rs
@@ -89,7 +89,7 @@ pub async fn post_remove(
                 if password != *"" {
                     let mut is_password_correct = false;
 
-                    if password == ARGS.auth_admin_password {
+                    if password == *ARGS.auth_admin_password {
                         is_password_correct = true;
                     }
 

--- a/src/util/auth.rs
+++ b/src/util/auth.rs
@@ -17,7 +17,7 @@ pub async fn auth_validator(
         creds.password(),
     ) {
         (Some(conf_user), Some(conf_pwd), Some(cred_pwd))
-            if creds.user_id() == conf_user && conf_pwd == cred_pwd =>
+            if creds.user_id() == **conf_user && **conf_pwd == cred_pwd =>
         {
             Ok(req)
         }


### PR DESCRIPTION
Implements #301 

For 5 auth-related ARG variables where we might want to provide the value as a file secret, it is now possible simply by providing the file path url:

```
MICROBIN_BASIC_AUTH_USERNAME
MICROBIN_BASIC_AUTH_PASSWORD
MICROBIN_ADMIN_USERNAME
MICROBIN_ADMIN_PASSWORD
MICROBIN_UPLOADER_PASSWORD
```

Previously, you could only set the values like

`MICROBIN_BASIC_AUTH_PASSWORD=password123`

But now, you can create a file called `secret_password.txt` anywhere on your system and simply refer to it like so:

`MICROBIN_BASIC_AUTH_PASSWORD=file://my/directory/secret_password.txt`


This implementation does not follow the *_FILE standard to avoid having to deal with two args for a single variable.