### PR TITLE
Add MICROBIN_MAX_EXPIRY arg

### DIFF
--- a/.env
+++ b/.env
@@ -170,9 +170,16 @@ export MICROBIN_ENABLE_READONLY=true
 export MICROBIN_EDITABLE=false
 
 # Sets the default expiry time setting on the main screen.
-# Default value: 24hour Available expiration options: 1min,
-# 10min, 1hour, 24hour, 1week, never
+# Default value: 24hour
+# Available expiration options: 1min, 10min, 1hour,
+# 24hour, 1week, 1month, 6months, 1year, 2years, 4years, 8years, 16years, never
 export MICROBIN_DEFAULT_EXPIRY=24hour
+
+# Sets the longest allowed expiry time setting on the main screen.
+# Default value: 1week 
+# Available expiration options: 1min, 10min, 1hour,
+# 24hour, 1week, 1month, 6months, 1year, 2years, 4years, 8years, 16years, never
+export MICROBIN_MAX_EXPIRY=1week
 
 # Disables and hides the file upload option in the UI.
 # Default value: false

--- a/src/args.rs
+++ b/src/args.rs
@@ -106,6 +106,9 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_DEFAULT_EXPIRY", default_value = "24hour")]
     pub default_expiry: String,
 
+    #[clap(long, env = "MICROBIN_MAX_EXPIRY", default_value = "1week")]
+    pub max_expiry: String,
+
     #[clap(long, env = "MICROBIN_DATA_DIR", default_value = "microbin_data")]
     pub data_dir: String,
 
@@ -175,6 +178,26 @@ impl Args {
         }
     }
 
+    pub fn max_expiry_index(&self) -> usize {
+        let options = &[
+            "1min",
+            "10min",
+            "1hour",
+            "24hour",
+            "3days",
+            "1week",
+            "1month",
+            "6months",
+            "1year",
+            "2years",
+            "4years",
+            "8years",
+            "16years",
+            "never",
+        ];
+        options.iter().position(|&x| x == self.max_expiry).unwrap_or(5)
+    }
+
     pub fn without_secrets(self) -> Args {
         Args {
             auth_basic_username: None,
@@ -209,6 +232,7 @@ impl Args {
             eternal_pasta: self.eternal_pasta,
             enable_readonly: self.enable_readonly,
             default_expiry: self.default_expiry,
+            max_expiry: self.max_expiry,
             data_dir: String::from(""),
             no_file_upload: self.no_file_upload,
             custom_css: self.custom_css,

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -24,6 +24,7 @@ struct IndexTemplate<'a> {
     args: &'a Args,
     status: String,
     default_privacy_value: String,
+    max_expiry_index: usize,
 }
 
 #[get("/")]
@@ -33,6 +34,7 @@ pub async fn index() -> impl Responder {
             args: &ARGS,
             status: String::from(""),
             default_privacy_value: ARGS.default_privacy.as_ref().map_or_else(|| String::from("public"), |s| s.clone()),
+            max_expiry_index: ARGS.max_expiry_index(),
         }
         .render()
         .unwrap(),
@@ -48,11 +50,29 @@ pub async fn index_with_status(param: web::Path<String>) -> HttpResponse {
             args: &ARGS,
             status,
             default_privacy_value: ARGS.default_privacy.as_ref().map_or_else(|| String::from("public"), |s| s.clone()),
+            max_expiry_index: ARGS.max_expiry_index(),
         }
         .render()
         .unwrap(),
     );
 }
+
+const EXPIRATION_OPTIONS: &[&str] = &[
+    "1min",
+    "10min",
+    "1hour",
+    "24hour",
+    "3days",
+    "1week",
+    "1month",
+    "6months",
+    "1year",
+    "2years",
+    "4years",
+    "8years",
+    "16years",
+    "never",
+];
 
 pub fn expiration_to_timestamp(expiration: &str, timenow: i64) -> i64 {
     match expiration {
@@ -62,6 +82,13 @@ pub fn expiration_to_timestamp(expiration: &str, timenow: i64) -> i64 {
         "24hour" => timenow + 60 * 60 * 24,
         "3days" => timenow + 60 * 60 * 24 * 3,
         "1week" => timenow + 60 * 60 * 24 * 7,
+        "1month" => timenow + 60 * 60 * 24 * 30,
+        "6months" => timenow + 60 * 60 * 24 * 30 * 6,
+        "1year" => timenow + 60 * 60 * 24 * 365,
+        "2years" => timenow + 60 * 60 * 24 * 365 * 2,
+        "4years" => timenow + 60 * 60 * 24 * 365 * 4,
+        "8years" => timenow + 60 * 60 * 24 * 365 * 8,
+        "16years" => timenow + 60 * 60 * 24 * 365 * 16,
         "never" => {
             if ARGS.eternal_pasta {
                 0
@@ -74,6 +101,12 @@ pub fn expiration_to_timestamp(expiration: &str, timenow: i64) -> i64 {
             timenow + 60 * 60 * 24 * 7
         }
     }
+}
+
+pub fn is_valid_expiration(expiration: &str, max_expiry: &str) -> bool {
+    let max_index = EXPIRATION_OPTIONS.iter().position(|&x| x == max_expiry).unwrap_or(5);
+    let current_index = EXPIRATION_OPTIONS.iter().position(|&x| x == expiration).unwrap_or(0);
+    current_index <= max_index
 }
 
 pub async fn create(
@@ -166,11 +199,16 @@ pub async fn create(
                 continue;
             }
             "expiration" => {
+                let mut expiration_str = String::new();
                 while let Some(chunk) = field.try_next().await? {
-                    new_pasta.expiration =
-                        expiration_to_timestamp(std::str::from_utf8(&chunk).unwrap(), timenow);
+                    expiration_str = std::str::from_utf8(&chunk).unwrap().to_string();
                 }
 
+                if !is_valid_expiration(&expiration_str, &ARGS.max_expiry) {
+                    return Err(ErrorBadRequest("Expiration exceeds maximum allowed"));
+                }
+
+                new_pasta.expiration = expiration_to_timestamp(&expiration_str, timenow);
                 continue;
             }
             "burn_after" => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,44 +6,112 @@
             <label for="expiration">Expiration <sup> <a href="{{ args.public_path_as_str() }}/guide#expiration">?</a></sup></label><br>
             <select style="width: 100%;" name="expiration" id="expiration">
                 <optgroup label="Expire after">
+                    {% if max_expiry_index >= 0 %}
                     {% if args.default_expiry == "1min" %}
                     <option selected value="1min">
                         {%- else %}
                     <option value="1min">
                         {%- endif %} 1 minute
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 1 %}
                     {% if args.default_expiry == "10min" %}
                     <option selected value="10min">
                         {%- else %}
                     <option value="10min">
                         {%- endif %} 10 minutes
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 2 %}
                     {% if args.default_expiry == "1hour" %}
                     <option selected value="1hour">
                         {%- else %}
                     <option value="1hour">
                         {%- endif %} 1 hour
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 3 %}
                     {% if args.default_expiry == "24hour" %}
                     <option selected value="24hour">
                         {%- else %}
                     <option value="24hour">
                         {%- endif %} 24 hours
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 4 %}
                     {% if args.default_expiry == "3days" %}
                     <option selected value="3days">
                         {%- else %}
                     <option value="3days">
                         {%- endif %} 3 days
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 5 %}
                     {% if args.default_expiry == "1week" %}
                     <option selected value="1week">
                         {%- else %}
                     <option value="1week">
                         {%- endif %} 1 week
                     </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 6 %}
+                    {% if args.default_expiry == "1month" %}
+                    <option selected value="1month">
+                        {%- else %}
+                    <option value="1month">
+                        {%- endif %} 1 month
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 7 %}
+                    {% if args.default_expiry == "6months" %}
+                    <option selected value="6months">
+                        {%- else %}
+                    <option value="6months">
+                        {%- endif %} 6 months
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 8 %}
+                    {% if args.default_expiry == "1year" %}
+                    <option selected value="1year">
+                        {%- else %}
+                    <option value="1year">
+                        {%- endif %} 1 year
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 9 %}
+                    {% if args.default_expiry == "2years" %}
+                    <option selected value="2years">
+                        {%- else %}
+                    <option value="2years">
+                        {%- endif %} 2 years
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 10 %}
+                    {% if args.default_expiry == "4years" %}
+                    <option selected value="4years">
+                        {%- else %}
+                    <option value="4years">
+                        {%- endif %} 4 years
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 11 %}
+                    {% if args.default_expiry == "8years" %}
+                    <option selected value="8years">
+                        {%- else %}
+                    <option value="8years">
+                        {%- endif %} 8 years
+                    </option>
+                    {%- endif %}
+                    {% if max_expiry_index >= 12 %}
+                    {% if args.default_expiry == "16years" %}
+                    <option selected value="16years">
+                        {%- else %}
+                    <option value="16years">
+                        {%- endif %} 16 years
+                    </option>
+                    {%- endif %}
                 </optgroup>
-                {% if args.eternal_pasta %} {% if args.default_expiry ==
+                {% if args.eternal_pasta && max_expiry_index >= 13 %} {% if args.default_expiry ==
                 "never" %}
                 <option selected value="never">
                     {%- else %}


### PR DESCRIPTION
Introduce a new arg `max_expiry` (default "1week") to limit selectable expiration choices, and extended supported expiration options from 1 week to 16 years. Implements #263