### PR TITLE
Security: expand pasta ID range to 2^53 with uniqueness check

### DIFF
--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -18,6 +18,10 @@ use rand::Rng;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub fn generate_pasta_id() -> u64 {
+    rand::thread_rng().gen::<u16>() as u64
+}
+
 #[derive(Template)]
 #[template(path = "index.html")]
 struct IndexTemplate<'a> {
@@ -122,7 +126,7 @@ pub async fn create(
     } as i64;
 
     let mut new_pasta = Pasta {
-        id: rand::thread_rng().gen::<u16>() as u64,
+        id: generate_pasta_id(),
         content: String::from(""),
         file: None,
         extension: String::from(""),
@@ -417,5 +421,17 @@ pub async fn create(
                     .finish(),
             )
             .finish())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id_not_confined_to_u16() {
+        let ids: Vec<u64> = (0..100).map(|_| generate_pasta_id()).collect();
+        assert!(ids.iter().any(|&id| id > u16::MAX as u64),
+            "All 100 IDs were <= 65535, indicating u16 range constraint");
     }
 }

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -18,8 +18,11 @@ use rand::Rng;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+// Cap at 2^53 - 1 (JS Number.MAX_SAFE_INTEGER) for compatibility with
+// SQLite signed i64 and JavaScript JSON consumers.
 pub fn generate_pasta_id() -> u64 {
-    rand::thread_rng().gen::<u16>() as u64
+    const MAX_SAFE_ID: u64 = 9_007_199_254_740_991;
+    rand::thread_rng().gen_range(0..=MAX_SAFE_ID)
 }
 
 #[derive(Template)]
@@ -335,7 +338,7 @@ pub async fn create(
         }
     }
 
-    let id = new_pasta.id;
+    let mut id = new_pasta.id;
 
     if plain_key != *"" && new_pasta.readonly {
         new_pasta.encrypted_key = Some(encrypt(id.to_string().as_str(), &plain_key));
@@ -379,6 +382,13 @@ pub async fn create(
 
     {
         let mut pastas = data.pastas.lock().unwrap();
+
+        // Ensure ID uniqueness
+        while pastas.iter().any(|p| p.id == new_pasta.id) {
+            new_pasta.id = generate_pasta_id();
+        }
+        id = new_pasta.id;
+
         pastas.push(new_pasta);
 
         for (_, pasta) in pastas.iter().enumerate() {


### PR DESCRIPTION
## Summary

Fixes #322 — pasta IDs were generated as 16-bit random numbers (`gen::<u16>() as u64`), allowing trivial enumeration of all pastas and silent ID collisions.

- Extract ID generation into `generate_pasta_id()` using `gen_range(0..=9_007_199_254_740_991)` (2^53 - 1)
- Add uniqueness check inside the existing mutex lock before insertion

## Why 2^53

Largest safe range that works across SQLite signed i64, JavaScript `Number.MAX_SAFE_INTEGER`, and the existing `u64` field. At 100 req/s, full enumeration takes ~2.8 million years.

## Backwards compatibility

Zero breaking changes. Existing pastas keep their small IDs, existing URLs continue to work. Only new pastas get longer animal-name slugs.

## Test plan

Test is designed to **fail without the fix and pass with the fix** using identical test code:

```rust
#[test]
fn test_id_not_confined_to_u16() {
    let ids: Vec<u64> = (0..100).map(|_| generate_pasta_id()).collect();
    assert!(ids.iter().any(|&id| id > u16::MAX as u64),
        "All 100 IDs were <= 65535, indicating u16 range constraint");
}
```

- [x] Test fails at commit 1 (old `gen::<u16>()` behavior) — verified via `cargo test`
- [x] Test passes at commit 2 (new `gen_range` behavior) — verified via `cargo test`
- [x] Build and test via: `docker run --rm -v $(pwd):/src -w /src deaddev/ubuntu:rust cargo test --bin microbin test_id_not_confined_to_u16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)