### PR TITLE
Security: replace forgeable Hashids owner_token with server-side UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "tempfile",
+ "uuid",
  "webpki-roots",
  "zip",
 ]
@@ -3575,6 +3576,17 @@ name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "v_htmlescape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3"
 harsh = "0.2"
 html-escape = "0.2.13"
 lazy_static = "1.4.0"
+uuid = { version = "1", features = ["v4"] }
 linkify = "0.10.0"
 log = "0.4.21"
 magic-crypt = "3.1.13"

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,14 @@ use std::str::FromStr;
 use crate::fs;
 
 lazy_static! {
-    pub static ref ARGS: Args = Args::parse();
+    // Under test, clap would consume the test harness's CLI arguments,
+    // so we initialize with program-name-only defaults instead.
+    pub static ref ARGS: Args = {
+        #[cfg(test)]
+        { Args::parse_from(&["microbin"]) }
+        #[cfg(not(test))]
+        { Args::parse() }
+    };
 }
 
 #[derive(Parser, Debug, Clone, Serialize)]

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -9,6 +9,7 @@ use actix_multipart::Multipart;
 use actix_web::error::ErrorBadRequest;
 use actix_web::cookie::Cookie;
 use actix_web::{get, web, Error, HttpResponse, Responder};
+use uuid::Uuid;
 use askama::Template;
 use bytes::BytesMut;
 use bytesize::ByteSize;
@@ -395,15 +396,16 @@ pub async fn create(
             .append_header(("Location", format!("{}/auth/{}/success", ARGS.public_path_as_str(), slug)))
             .finish())
     } else {
-        // Generate time-limited token for initial view using Hashids
         let timenow = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let expiry = timenow + 15; // 15 seconds validity
-        
-        // Use global HARSH instance
-        let encoded_token = crate::util::hashids::HARSH.encode(&[expiry, id]);
+        let encoded_token = Uuid::new_v4().to_string();
+        // Store token server-side so it can't be forged
+        crate::endpoints::pasta::OWNER_TOKENS
+            .lock()
+            .unwrap()
+            .insert(id, (encoded_token.clone(), timenow + 15));
 
         Ok(HttpResponse::Found()
             .append_header((

--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -12,7 +12,13 @@ use actix_web::{get, post, web, Error, HttpRequest, HttpResponse};
 use askama::Template;
 use magic_crypt::{new_magic_crypt, MagicCryptTrait};
 
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+lazy_static::lazy_static! {
+    pub static ref OWNER_TOKENS: StdMutex<HashMap<u64, (String, u64)>> = StdMutex::new(HashMap::new());
+}
 
 #[derive(Template)]
 #[template(path = "upload.html", escape = "none")]
@@ -169,25 +175,16 @@ pub async fn getpasta(
 // when creating a pasta, the owner is issued a token with a 15-second expiration
 // this token is used to avoid incrementing the read count of the pasta when the owner views it
 fn verify_owner_token(token: &str, id: &str) -> bool {
-    // decode the token
-    if let Ok(numbers) = crate::util::hashids::HARSH.decode(token) {
-        if numbers.len() == 2 {
-            let expiry = numbers[0];
-            let token_id = numbers[1];
-            let timenow = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let pasta_id = if ARGS.hash_ids {
+        hashid_to_u64(id).unwrap_or(0)
+    } else {
+        to_u64(id).unwrap_or(0)
+    };
 
-            // verify the token is valid
-            let target_id = if ARGS.hash_ids {
-                hashid_to_u64(id).unwrap_or(0)
-            } else {
-                to_u64(id).unwrap_or(0)
-            };
-
-            if token_id == target_id && expiry > timenow {
-                // yay, it's valid
-                return true;
-            }
-        }
+    let tokens = OWNER_TOKENS.lock().unwrap();
+    if let Some((stored_token, expiry)) = tokens.get(&pasta_id) {
+        let timenow = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        return token == stored_token && *expiry > timenow;
     }
     false
 }

--- a/src/endpoints/pasta.rs
+++ b/src/endpoints/pasta.rs
@@ -449,3 +449,19 @@ fn decrypt(text_str: &str, key_str: &str) -> Result<String, magic_crypt::MagicCr
 
     mc.decrypt_base64_to_string(text_str)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hashids_forged_token_rejected() {
+        let pasta_id: u64 = 12345;
+        let id_str = crate::util::animalnumbers::to_animal_names(pasta_id);
+        let timenow = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let forged_token = crate::util::hashids::HARSH.encode(&[timenow + 3600, pasta_id]);
+        // A forged Hashids token must NOT be accepted
+        assert!(!verify_owner_token(&forged_token, &id_str),
+            "Forged Hashids token was accepted - owner_token is forgeable!");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #323 — the `owner_token` cookie used to skip burn-after-read counting was generated using unsalted Hashids encoding of two public values (expiry timestamp + pasta ID). Any reader could forge it and read burn-after-read pastas indefinitely.

- Replace Hashids token with `uuid::Uuid::new_v4()` stored in a server-side `HashMap<u64, (String, u64)>`
- Verify by comparing cookie value against server state instead of self-validating decode
- Function signature `verify_owner_token(token: &str, id: &str) -> bool` unchanged

## Design choices

- **In-memory map, not Pasta struct field**: token is only relevant for 15-second post-creation window. No DB schema change needed.
- **`std::sync::Mutex`**: map access is brief insert/lookup, no `.await` held across lock.
- Adds `uuid = { version = "1", features = ["v4"] }` dependency.

## Backwards compatibility

Zero breaking changes. No Pasta struct changes, no DB migration, no URL changes. Existing pastas have no map entry, so `verify_owner_token` returns false (same as expired token).

## Test plan

Test is designed to **fail without the fix and pass with the fix** using identical test code:

```rust
#[test]
fn test_hashids_forged_token_rejected() {
    let pasta_id: u64 = 12345;
    let id_str = to_animal_names(pasta_id);
    let timenow = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
    let forged_token = HARSH.encode(&[timenow + 3600, pasta_id]);
    assert!(!verify_owner_token(&forged_token, &id_str),
        "Forged Hashids token was accepted - owner_token is forgeable!");
}
```

- [x] Test fails at commit 1 (old Hashids verification accepts forged token) — verified via `cargo test`
- [x] Test passes at commit 2 (UUID map rejects forged token) — verified via `cargo test`
- [x] Build and test via: `docker run --rm -v $(pwd):/src -w /src deaddev/ubuntu:rust cargo test --bin microbin test_hashids_forged_token_rejected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)