### PR TITLE
Patch #326, change env defaults, bump to 2.1.4

### DIFF
--- a/.env
+++ b/.env
@@ -35,8 +35,8 @@ export MICROBIN_ADMIN_USERNAME=admin
 # Enables administrator interface password at yourserver.com/admin/
 # Supports reading the value from a file e.g. file://secret_password.txt
 # Use file:// preset, then global/local path.
-# Default value: admin
-export MICROBIN_ADMIN_PASSWORD=admin
+# Default value: m1cr0b1n
+export MICROBIN_ADMIN_PASSWORD=m1cr0b1n
 
 # Enables administrator interface at yourserver.com/admin/
 # if set, disables it if unset. Will not have any affect
@@ -114,13 +114,17 @@ export MICROBIN_JSON_DB=false
 # unset.Example value: https://b.in/ export
 # MICROBIN_SHORT_PATH=
 
-# The password required for uploading, if read-only mode is enabled
+# Password required for uploading when MICROBIN_READONLY=true. If set, users
+# must enter this password to create new pastas (server-wide upload restriction).
+# Has no effect unless MICROBIN_READONLY=true.
 # Supports reading the value from a file e.g. file://secret_password.txt
 # Use file:// preset, then global/local path.
 # Default value: unset
 # export MICROBIN_UPLOADER_PASSWORD=
 
-# If set to true, authentication required for uploading
+# Restricts the entire server to read-only mode: no new pastas can be created
+# unless the user provides MICROBIN_UPLOADER_PASSWORD. This is a server-wide
+# lockdown, not related to per-pasta read-only privacy (see MICROBIN_ENABLE_READONLY).
 # Default value: false
 export MICROBIN_READONLY=false
 
@@ -163,15 +167,16 @@ export MICROBIN_WIDE=false
 # Enables generating QR codes for pastas. Requires
 # the public path to also be set.
 # Default value: false
-export MICROBIN_QR=true
+export MICROBIN_QR=false
 
 # Toggles "Never" expiry settings for pastas. Default
 # value: false
 export MICROBIN_ETERNAL_PASTA=false
 
-# Enables "Protected" uploads (Read-only). These are unlisted and
-# unencrypted, but can be viewed without password if you
-# have the URL. Content modification and deletion requires password.
+# Enables the per-pasta "Read-only" privacy option in the UI. When enabled,
+# users can create pastas that are unlisted and unencrypted, viewable by
+# anyone with the URL, but require a password to edit or delete.
+# Note: This is unrelated to MICROBIN_READONLY (server-wide upload restriction).
 # Default value: true
 export MICROBIN_ENABLE_READONLY=true
 
@@ -181,7 +186,7 @@ export MICROBIN_ENABLE_READONLY=true
 # Note: The setting is saved to each upload on creation. If you change this variable,
 # old uploads will still reflect the setting at the time of creation.
 # Default value: true
-export MICROBIN_EDITABLE=false
+export MICROBIN_EDITABLE=true
 
 # Sets the default expiry time setting on the main screen.
 # Default value: 24hour

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ secrets.DOCKERHUB_REPO }}
+          flavor: |
+            latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,7 +2049,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "microbin"
-version = "2.1.2"
+version = "2.1.4"
 dependencies = [
  "actix-files",
  "actix-multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbin"
-version = "2.1.2"
+version = "2.1.4"
 edition = "2021"
 rust-version = "1.74.0"
 authors = ["Daniel Szabo <daniel@microbin.eu>"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -26,7 +26,7 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_ADMIN_PASSWORD", default_value = "m1cr0b1n")]
     pub auth_admin_password: SecretArg,
 
-    #[clap(long, env = "MICROBIN_EDITABLE")]
+    #[clap(long, env = "MICROBIN_EDITABLE", action = clap::ArgAction::Set, default_value_t = true)]
     pub editable: bool,
 
     #[clap(long, env = "MICROBIN_FOOTER_TEXT")]
@@ -44,7 +44,7 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_NO_LISTING")]
     pub no_listing: bool,
 
-    #[clap(long, env = "MICROBIN_HIGHLIGHTSYNTAX")]
+    #[clap(long, env = "MICROBIN_HIGHLIGHTSYNTAX", action = clap::ArgAction::Set, default_value_t = true)]
     pub highlightsyntax: bool,
 
     #[clap(short, long, env = "MICROBIN_PORT", default_value_t = 8080)]
@@ -53,7 +53,7 @@ pub struct Args {
     #[clap(short, long, env="MICROBIN_BIND", default_value_t = IpAddr::from([0, 0, 0, 0]))]
     pub bind: IpAddr,
 
-    #[clap(long, env = "MICROBIN_PRIVATE")]
+    #[clap(long, env = "MICROBIN_PRIVATE", action = clap::ArgAction::Set, default_value_t = true)]
     pub private: bool,
 
     #[clap(long, env = "MICROBIN_PURE_HTML")]
@@ -74,7 +74,7 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_READONLY")]
     pub readonly: bool,
 
-    #[clap(long, env = "MICROBIN_SHOW_READ_STATS")]
+    #[clap(long, env = "MICROBIN_SHOW_READ_STATS", action = clap::ArgAction::Set, default_value_t = true)]
     pub show_read_stats: bool,
 
     #[clap(long, env = "MICROBIN_TITLE")]
@@ -86,7 +86,7 @@ pub struct Args {
     #[clap(short, long, env = "MICROBIN_GC_DAYS", default_value_t = 90)]
     pub gc_days: u16,
 
-    #[clap(long, env = "MICROBIN_ENABLE_BURN_AFTER")]
+    #[clap(long, env = "MICROBIN_ENABLE_BURN_AFTER", action = clap::ArgAction::Set, default_value_t = true)]
     pub enable_burn_after: bool,
 
     #[clap(short, long, env = "MICROBIN_DEFAULT_BURN_AFTER", default_value_t = 0)]
@@ -101,7 +101,7 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_ETERNAL_PASTA")]
     pub eternal_pasta: bool,
 
-    #[clap(long, env = "MICROBIN_ENABLE_READONLY")]
+    #[clap(long, env = "MICROBIN_ENABLE_READONLY", action = clap::ArgAction::Set, default_value_t = true)]
     pub enable_readonly: bool,
 
     #[clap(long, env = "MICROBIN_DEFAULT_EXPIRY", default_value = "24hour")]
@@ -131,10 +131,10 @@ pub struct Args {
     #[clap(long, env = "MICROBIN_DISABLE_UPDATE_CHECKING")]
     pub disable_update_checking: bool,
 
-    #[clap(long, env = "MICROBIN_ENCRYPTION_CLIENT_SIDE")]
+    #[clap(long, env = "MICROBIN_ENCRYPTION_CLIENT_SIDE", action = clap::ArgAction::Set, default_value_t = true)]
     pub encryption_client_side: bool,
 
-    #[clap(long, env = "MICROBIN_ENCRYPTION_SERVER_SIDE")]
+    #[clap(long, env = "MICROBIN_ENCRYPTION_SERVER_SIDE", action = clap::ArgAction::Set, default_value_t = true)]
     pub encryption_server_side: bool,
 
     #[clap(long, env = "MICROBIN_DEFAULT_PRIVACY")]

--- a/src/endpoints/create.rs
+++ b/src/endpoints/create.rs
@@ -171,7 +171,7 @@ pub async fn create(
                         _ => true,
                     };
                     new_pasta.readonly = match privacy {
-                        "readonly" => true,
+                        "readonly" if ARGS.enable_readonly => true,
                         _ => false,
                     };
                     new_pasta.encrypt_client = match privacy {

--- a/templates/index.html
+++ b/templates/index.html
@@ -422,7 +422,7 @@
             const fileSize = hiddenFileButton.files.item(0).size;
             const fileSizeMb = fileSize / 1024 ** 2;
 
-            if (privacyDropdown.value == "secret") {
+            if (privacyDropdown?.value == "secret") {
                 if (fileSizeMb >
                     parseInt("{{ args.max_file_size_encrypted_mb }}")) {
                     attachFileButton.textContent = "Please select a file smaller than {{ args.max_file_size_encrypted_mb }} MB";


### PR DESCRIPTION
Patches index.html javascript error cause by MICROBIN_PRIVATE being set to false. Updates arg default values across the default .env file and args.rs for consistency. Bumps to 2.1.4. Updated release.yml workflow to also push the :latest image on DockerHub.