### PR TITLE
Implement audio and new arg to inline all media

### DIFF
--- a/.env
+++ b/.env
@@ -204,6 +204,11 @@ export MICROBIN_MAX_EXPIRY=1week
 # Default value: false
 export MICROBIN_NO_FILE_UPLOAD=false
 
+# When enabled, image, video and audio files are served
+# inline in the browser instead of being downloaded.
+# Default value: false
+export MICROBIN_INLINE_MEDIA=false
+
 # Replaced the built-in water.css stylesheet with the URL
 # you provide. Default value: unset. Example value:
 # https://myserver.net/public/mystyle.css 

--- a/src/args.rs
+++ b/src/args.rs
@@ -158,6 +158,9 @@ pub struct Args {
 
     #[clap(long, env = "MICROBIN_DEFAULT_VIEW", default_value = "gallery")]
     pub default_view: String,
+
+    #[clap(long, env = "MICROBIN_INLINE_MEDIA", action = clap::ArgAction::Set, default_value_t = false)]
+    pub inline_media: bool,
 }
 
 impl Args {
@@ -247,6 +250,7 @@ impl Args {
             disable_update_checking: self.disable_update_checking,
 
             default_view: self.default_view,
+            inline_media: self.inline_media,
         }
     }
 }

--- a/src/endpoints/file.rs
+++ b/src/endpoints/file.rs
@@ -197,7 +197,9 @@ pub async fn get_file(
             // file path
             let file_reponse = actix_files::NamedFile::open(file_path)?;
             
-            let disposition = if query.get("preview").map(|s| s == "true").unwrap_or(false) {
+            let disposition = if query.get("preview").map(|s| s == "true").unwrap_or(false)
+                || (ARGS.inline_media && pasta_file.embeddable())
+            {
                 header::DispositionType::Inline
             } else {
                 header::DispositionType::Attachment

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -57,8 +57,16 @@ impl PastaFile {
         extensions.iter().any(|&ext| lowercase_name.ends_with(ext))
     }
 
+    pub fn is_audio(&self) -> bool {
+        let lowercase_name = self.name.to_lowercase();
+        let extensions = [
+            ".mp3", ".ogg", ".wav", ".flac", ".aac", ".m4a", ".opus", ".weba",
+        ];
+        extensions.iter().any(|&ext| lowercase_name.ends_with(ext))
+    }
+
     pub fn embeddable(&self) -> bool {
-        self.is_image() || self.is_video()
+        self.is_image() || self.is_video() || self.is_audio()
     }
 
     pub fn extension(&self) -> String {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -130,6 +130,8 @@
                         Image
                         {%- else if pasta.file.as_ref().unwrap().is_video() %}
                         Video
+                        {%- else if pasta.file.as_ref().unwrap().is_audio() %}
+                        Audio
                         {%- else %}
                         File
                         {%- endif %}
@@ -238,6 +240,8 @@
                             Image
                             {%- else if pasta.file.as_ref().unwrap().is_video() %}
                             Video
+                            {%- else if pasta.file.as_ref().unwrap().is_audio() %}
+                            Audio
                             {%- else %}
                             File
                             {%- endif %}

--- a/templates/assets/file_card.html
+++ b/templates/assets/file_card.html
@@ -6,6 +6,8 @@
     </a>
     {% else if file.is_video() %}
     <video class="embed-media" controls src="{{ args.public_path_as_str()}}/file/{{pasta.id_as_animals()}}?fname={{ file.url_encoded_name() }}"></video>
+    {% else if file.is_audio() %}
+    <audio class="embed-media" controls src="{{ args.public_path_as_str()}}/file/{{pasta.id_as_animals()}}?fname={{ file.url_encoded_name() }}"></audio>
     {% else %}
     <div class="embed-media" style="display: flex; align-items: center; justify-content: center; background-color: #eee; color: #555;">
         <span>{{ file.extension() }}</span>

--- a/templates/list.html
+++ b/templates/list.html
@@ -78,6 +78,8 @@
                             Image
                             {%- else if pasta.file.as_ref().unwrap().is_video() %}
                             Video
+                            {%- else if pasta.file.as_ref().unwrap().is_audio() %}
+                            Audio
                             {%- else %}
                             File
                             {%- endif %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -140,6 +140,22 @@ pasta.file_embeddable() && !pasta.encrypt_client && !pasta.attachments.is_some()
 </span>
 {%- endif %}
 
+
+{% if pasta.file.is_some() && pasta.file.as_ref().unwrap().is_audio() &&
+pasta.file_embeddable() && !pasta.encrypt_client && !pasta.attachments.is_some() %}
+<audio id="embed" controls src="{{ args.public_path_as_str()}}/file/{{pasta.id_as_animals()}}"></audio>
+<span style="margin-left: auto; margin-right: auto; display: flex;
+  justify-content: center; align-items: center;">
+  <p style="font-size: small;">{{pasta.file.as_ref().unwrap().name()}}
+    [{{pasta.file.as_ref().unwrap().size}}]</p>
+  <a href="{{ args.public_path_as_str()      }}/file/{{pasta.id_as_animals()}}" download id="download-link">
+    <button class="download-button">
+      Download
+    </button>
+  </a>
+</span>
+{%- endif %}
+
 {% if pasta.attachments.is_some() %}
 <div id="gallery-view" class="gallery-grid" style="display: grid; margin-top: 2rem;">
     {% if pasta.file.is_some() %}
@@ -535,6 +551,11 @@ pasta.file_embeddable() && !pasta.encrypt_client && !pasta.attachments.is_some()
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  audio#embed {
+    width: 100%;
+    max-width: 600px;
   }
 
   .download-button {


### PR DESCRIPTION
This is a super cool project! Sorry for using AI but I promise I tested the crap out of this on my homelab before opening the PR. The gist of what I think was missing was no way to just see an image/video (or  listen to an audio) after doing an upload.

A new arg lets this behavior be toggled in .env and then boilerplate stuff to support audio in a similar way that images and video are handled based on if the inline arg is set or not. When the arg is set when you go to host.tld/file/hash-or-animalname instead of just downloading the file it will be displayed directly in the browser.

I'm happy to squash the commits and use my own name/email/phrasing if you don't like what claude generated (I'm not a huge fan but I must admit I didn't write it.)

I tested an image, audio, and video with the new arg set true and false and got the expected behavior on my homelab. If you want to try this on the internet with it set to true before even bothering to build it check out bin.4tw.pw