### PR TITLE
Fix reversed comments in .env

### DIFF
--- a/.env
+++ b/.env
@@ -221,14 +221,14 @@ export MICROBIN_HASH_IDS=false
 # server sees everything that the user submits, therefore
 # the user does not have complete and absolute protection.
 # Default value: false
-export MICROBIN_ENCRYPTION_CLIENT_SIDE=true
+export MICROBIN_ENCRYPTION_SERVER_SIDE=true
 
 # Enables client-side encryption. This will add the secret
 # privacy level where the user's browser encrypts all data
 # with JavaScript before sending it over to MicroBin, which
 # encrypt the data once again on server side.
 # Default value: false
-export MICROBIN_ENCRYPTION_SERVER_SIDE=true
+export MICROBIN_ENCRYPTION_CLIENT_SIDE=true
 
 # Sets the default privacy level for new pastas. Available options:
 # public - shows in listing, no password required

--- a/.env
+++ b/.env
@@ -240,14 +240,14 @@ export MICROBIN_ENCRYPTION_SERVER_SIDE=true
 # export MICROBIN_DEFAULT_PRIVACY=
 
 # Limit the maximum file size users can upload without
-# encryption. Default value: 256.
-export MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB=256
+# encryption. Default value: 2048.
+export MICROBIN_MAX_FILE_SIZE_UNENCRYPTED_MB=2048
 
 # Limit the maximum file size users can upload with
 # encryption (more strain on your server than without
 # encryption, so the limit should be lower. Secrets tend to
-# be tiny files usually anyways.) Default value: 2048.
-export MICROBIN_MAX_FILE_SIZE_UNENCRYPTED_MB=2048
+# be tiny files usually anyways.) Default value: 256.
+export MICROBIN_MAX_FILE_SIZE_ENCRYPTED_MB=256
 
 # Disables the feature that checks for available updates
 #  when opening the admin screen.


### PR DESCRIPTION
Only changes the ordering around `export`ed variables in two places, no change in functionality.