### PR TITLE
fix(env): incorrect description for MICROBIN_FOOTER_TEXT

### DIFF
--- a/.env
+++ b/.env
@@ -38,9 +38,9 @@ export MICROBIN_ADMIN_USERNAME=admin
 # Default value: m1cr0b1n
 export MICROBIN_ADMIN_PASSWORD=m1cr0b1n
 
-# Enables administrator interface at yourserver.com/admin/
-# if set, disables it if unset. Will not have any affect
-# unless admin username is also set. If admin username is
+# Replaces the default footer text with your own. If you
+# want to hide the footer, use the hide footer option instead.
+# Note that you can also embed HTML here, so you may want to escape
 # '<', '>' and so on.
 # export MICROBIN_FOOTER_TEXT=
 


### PR DESCRIPTION
It seems like the descriptive comment for the `MICROBIN_FOOTER_TEXT` environment variable was accidentally partially deleted in [this PR](https://github.com/szabodanika/microbin/commit/f8d091b6d01eeb694f289b692c9a5886152e41dc#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dL44-R33) and then later substituted with comments related to `MICROBIN_ADMIN_USERNAME`. This PR just reverts it back to the way it was before.

Closes #342.