### PR TITLE
Support do armhf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN \
   CARGO_NET_GIT_FETCH_WITH_CLI=true \
   cargo build --release
 
-# https://hub.docker.com/r/bitnami/minideb
-FROM bitnami/minideb:latest
+#Support to armv7
+#https://hub.docker.com/_/debian
+FROM debian:trixie-slim
 
 # microbin will be in /app
 WORKDIR /app


### PR DESCRIPTION
Changing the image to debian:trixie-slim will not cause permanent changes to the project, but it will provide support for the armhf architecture.