### PR TITLE
use explicit column order when reading from sqlite

### DIFF
--- a/src/util/db_sqlite.rs
+++ b/src/util/db_sqlite.rs
@@ -133,7 +133,30 @@ pub fn select_all_from_db() -> Vec<Pasta> {
     let _ = conn.execute("ALTER TABLE pasta ADD COLUMN attachments TEXT", params![]);
 
     let mut stmt = conn
-        .prepare("SELECT * FROM pasta ORDER BY created ASC")
+        .prepare(
+            "
+            SELECT
+                id,
+                content,
+                file_name,
+                file_size,
+                extension,
+                read_only,
+                private,
+                editable,
+                encrypt_server,
+                encrypt_client,
+                encrypted_key,
+                created,
+                expiration,
+                last_read,
+                read_count,
+                burn_after_reads,
+                pasta_type,
+                attachments
+            FROM pasta
+            ORDER BY created ASC;"
+        )
         .expect("Failed to prepare SQL statement to load pastas");
 
     let pasta_iter = stmt


### PR DESCRIPTION
Tables created after the introduction of the \`attachments' column have a
different schema order than existing tables altered to add this column\.
Although rows are inserted correctly, they are read through a \`SELECT \*'
query using positional references, resulting in \`pasta\_type' and
\`attachments' values getting swapped in memory for newer tables\.

This results in the \`/list' endpoint missing all existing rows after a
restart\. Furthermore, any operation that updates the database, such as a
read count update, updates the database with the swapped values,
permanently corrupting those rows\.

Using an explicit column order in the SELECT query is the obvious fix to
support both older and newer tables\. This commit does not address
already\-corrupted data\.